### PR TITLE
Provide terminal colors map to templates

### DIFF
--- a/base16
+++ b/base16
@@ -87,8 +87,31 @@ class Theme
         "srgb" => to_srgb(hex)
       }
     end
+
+    @terminal_colors = map_terminal_colors_to(@base)
   end
   
+  def map_terminal_colors_to(base)
+    {
+      :black          => @base["00"],
+      :blue           => @base["0D"],
+      :green          => @base["0B"],
+      :cyan           => @base["0C"],
+      :red            => @base["08"],
+      :magenta        => @base["0E"],
+      :yellow         => @base["0A"],
+      :white          => @base["05"],
+      :bright_black   => @base["03"],
+      :bright_blue    => @base["04"],
+      :bright_green   => @base["01"],
+      :bright_cyan    => @base["0F"],
+      :bright_red     => @base["09"],
+      :bright_magenta => @base["06"],
+      :bright_yellow  => @base["02"],
+      :bright_white   => @base["07"]
+    }
+  end
+
   def create_output_files
     # Read each 
     read_template_dir.each do |template_file|

--- a/base16
+++ b/base16
@@ -88,10 +88,10 @@ class Theme
       }
     end
 
-    @terminal_colors = map_terminal_colors_to(@base)
+    @terminal_colors = terminal_colors_map
   end
   
-  def map_terminal_colors_to(base)
+  def terminal_colors_map
     {
       :black          => @base["00"],
       :blue           => @base["0D"],

--- a/templates/console2/256.console.xml.erb
+++ b/templates/console2/256.console.xml.erb
@@ -2,22 +2,22 @@
 <settings>
 	<console>
 		<colors>
-			<color id="0" r="<%= @base["00"]["rgb"][0] %>" g="<%= @base["00"]["rgb"][1] %>" b="<%= @base["00"]["rgb"][2] %>"/>
-			<color id="1" r="<%= @base["0D"]["rgb"][0] %>" g="<%= @base["0D"]["rgb"][1] %>" b="<%= @base["0D"]["rgb"][2] %>"/>
-			<color id="2" r="<%= @base["0B"]["rgb"][0] %>" g="<%= @base["0B"]["rgb"][1] %>" b="<%= @base["0B"]["rgb"][2] %>"/>
-			<color id="3" r="<%= @base["0C"]["rgb"][0] %>" g="<%= @base["0C"]["rgb"][1] %>" b="<%= @base["0C"]["rgb"][2] %>"/>
-			<color id="4" r="<%= @base["08"]["rgb"][0] %>" g="<%= @base["08"]["rgb"][1] %>" b="<%= @base["08"]["rgb"][2] %>"/>
-			<color id="5" r="<%= @base["0E"]["rgb"][0] %>" g="<%= @base["0E"]["rgb"][1] %>" b="<%= @base["0E"]["rgb"][2] %>"/>
-			<color id="6" r="<%= @base["0A"]["rgb"][0] %>" g="<%= @base["0A"]["rgb"][1] %>" b="<%= @base["0A"]["rgb"][2] %>"/>
-			<color id="7" r="<%= @base["05"]["rgb"][0] %>" g="<%= @base["05"]["rgb"][1] %>" b="<%= @base["05"]["rgb"][2] %>"/>
-			<color id="8" r="<%= @base["03"]["rgb"][0] %>" g="<%= @base["03"]["rgb"][1] %>" b="<%= @base["03"]["rgb"][2] %>"/>
-			<color id="9" r="<%= @base["0D"]["rgb"][0] %>" g="<%= @base["0D"]["rgb"][1] %>" b="<%= @base["0D"]["rgb"][2] %>"/>
-			<color id="10" r="<%= @base["0B"]["rgb"][0] %>" g="<%= @base["0B"]["rgb"][1] %>" b="<%= @base["0B"]["rgb"][2] %>"/>
-			<color id="11" r="<%= @base["0C"]["rgb"][0] %>" g="<%= @base["0C"]["rgb"][1] %>" b="<%= @base["0C"]["rgb"][2] %>"/>
-			<color id="12" r="<%= @base["08"]["rgb"][0] %>" g="<%= @base["08"]["rgb"][1] %>" b="<%= @base["08"]["rgb"][2] %>"/>
-			<color id="13" r="<%= @base["0E"]["rgb"][0] %>" g="<%= @base["0E"]["rgb"][1] %>" b="<%= @base["0E"]["rgb"][2] %>"/>
-			<color id="14" r="<%= @base["0A"]["rgb"][0] %>" g="<%= @base["0A"]["rgb"][1] %>" b="<%= @base["0A"]["rgb"][2] %>"/>
-			<color id="15" r="<%= @base["07"]["rgb"][0] %>" g="<%= @base["07"]["rgb"][1] %>" b="<%= @base["07"]["rgb"][2] %>"/>
+			<color id="0" r="<%= @terminal_colors[:black]["rgb"][0] %>" g="<%= @terminal_colors[:black]["rgb"][1] %>" b="<%= @terminal_colors[:black]["rgb"][2] %>"/>
+			<color id="1" r="<%= @terminal_colors[:blue]["rgb"][0] %>" g="<%= @terminal_colors[:blue]["rgb"][1] %>" b="<%= @terminal_colors[:blue]["rgb"][2] %>"/>
+			<color id="2" r="<%= @terminal_colors[:green]["rgb"][0] %>" g="<%= @terminal_colors[:green]["rgb"][1] %>" b="<%= @terminal_colors[:green]["rgb"][2] %>"/>
+			<color id="3" r="<%= @terminal_colors[:cyan]["rgb"][0] %>" g="<%= @terminal_colors[:cyan]["rgb"][1] %>" b="<%= @terminal_colors[:cyan]["rgb"][2] %>"/>
+			<color id="4" r="<%= @terminal_colors[:red]["rgb"][0] %>" g="<%= @terminal_colors[:red]["rgb"][1] %>" b="<%= @terminal_colors[:red]["rgb"][2] %>"/>
+			<color id="5" r="<%= @terminal_colors[:magenta]["rgb"][0] %>" g="<%= @terminal_colors[:magenta]["rgb"][1] %>" b="<%= @terminal_colors[:magenta]["rgb"][2] %>"/>
+			<color id="6" r="<%= @terminal_colors[:yellow]["rgb"][0] %>" g="<%= @terminal_colors[:yellow]["rgb"][1] %>" b="<%= @terminal_colors[:yellow]["rgb"][2] %>"/>
+			<color id="7" r="<%= @terminal_colors[:white]["rgb"][0] %>" g="<%= @terminal_colors[:white]["rgb"][1] %>" b="<%= @terminal_colors[:white]["rgb"][2] %>"/>
+			<color id="8" r="<%= @terminal_colors[:bright_black]["rgb"][0] %>" g="<%= @terminal_colors[:bright_black]["rgb"][1] %>" b="<%= @terminal_colors[:bright_black]["rgb"][2] %>"/>
+			<color id="9" r="<%= @terminal_colors[:blue]["rgb"][0] %>" g="<%= @terminal_colors[:blue]["rgb"][1] %>" b="<%= @terminal_colors[:blue]["rgb"][2] %>"/>
+			<color id="10" r="<%= @terminal_colors[:green]["rgb"][0] %>" g="<%= @terminal_colors[:green]["rgb"][1] %>" b="<%= @terminal_colors[:green]["rgb"][2] %>"/>
+			<color id="11" r="<%= @terminal_colors[:cyan]["rgb"][0] %>" g="<%= @terminal_colors[:cyan]["rgb"][1] %>" b="<%= @terminal_colors[:cyan]["rgb"][2] %>"/>
+			<color id="12" r="<%= @terminal_colors[:red]["rgb"][0] %>" g="<%= @terminal_colors[:red]["rgb"][1] %>" b="<%= @terminal_colors[:red]["rgb"][2] %>"/>
+			<color id="13" r="<%= @terminal_colors[:magenta]["rgb"][0] %>" g="<%= @terminal_colors[:magenta]["rgb"][1] %>" b="<%= @terminal_colors[:magenta]["rgb"][2] %>"/>
+			<color id="14" r="<%= @terminal_colors[:yellow]["rgb"][0] %>" g="<%= @terminal_colors[:yellow]["rgb"][1] %>" b="<%= @terminal_colors[:yellow]["rgb"][2] %>"/>
+			<color id="15" r="<%= @terminal_colors[:bright_white]["rgb"][0] %>" g="<%= @terminal_colors[:bright_white]["rgb"][1] %>" b="<%= @terminal_colors[:bright_white]["rgb"][2] %>"/>
 		</colors>
 	</console>
 </settings>

--- a/templates/console2/256.console.xml.erb
+++ b/templates/console2/256.console.xml.erb
@@ -8,8 +8,8 @@
 			<color id="3" r="<%= @base["0C"]["rgb"][0] %>" g="<%= @base["0C"]["rgb"][1] %>" b="<%= @base["0C"]["rgb"][2] %>"/>
 			<color id="4" r="<%= @base["08"]["rgb"][0] %>" g="<%= @base["08"]["rgb"][1] %>" b="<%= @base["08"]["rgb"][2] %>"/>
 			<color id="5" r="<%= @base["0E"]["rgb"][0] %>" g="<%= @base["0E"]["rgb"][1] %>" b="<%= @base["0E"]["rgb"][2] %>"/>
-			<color id="6" r="<%= @base["09"]["rgb"][0] %>" g="<%= @base["09"]["rgb"][1] %>" b="<%= @base["09"]["rgb"][2] %>"/>
-			<color id="7" r="<%= @base["06"]["rgb"][0] %>" g="<%= @base["06"]["rgb"][1] %>" b="<%= @base["06"]["rgb"][2] %>"/>
+			<color id="6" r="<%= @base["0A"]["rgb"][0] %>" g="<%= @base["0A"]["rgb"][1] %>" b="<%= @base["0A"]["rgb"][2] %>"/>
+			<color id="7" r="<%= @base["05"]["rgb"][0] %>" g="<%= @base["05"]["rgb"][1] %>" b="<%= @base["05"]["rgb"][2] %>"/>
 			<color id="8" r="<%= @base["03"]["rgb"][0] %>" g="<%= @base["03"]["rgb"][1] %>" b="<%= @base["03"]["rgb"][2] %>"/>
 			<color id="9" r="<%= @base["0D"]["rgb"][0] %>" g="<%= @base["0D"]["rgb"][1] %>" b="<%= @base["0D"]["rgb"][2] %>"/>
 			<color id="10" r="<%= @base["0B"]["rgb"][0] %>" g="<%= @base["0B"]["rgb"][1] %>" b="<%= @base["0B"]["rgb"][2] %>"/>

--- a/templates/console2/console.xml.erb
+++ b/templates/console2/console.xml.erb
@@ -2,22 +2,22 @@
 <settings>
 	<console>
 		<colors>
-			<color id="0" r="<%= @base["00"]["rgb"][0] %>" g="<%= @base["00"]["rgb"][1] %>" b="<%= @base["00"]["rgb"][2] %>"/>
-			<color id="1" r="<%= @base["0D"]["rgb"][0] %>" g="<%= @base["0D"]["rgb"][1] %>" b="<%= @base["0D"]["rgb"][2] %>"/>
-			<color id="2" r="<%= @base["0B"]["rgb"][0] %>" g="<%= @base["0B"]["rgb"][1] %>" b="<%= @base["0B"]["rgb"][2] %>"/>
-			<color id="3" r="<%= @base["0C"]["rgb"][0] %>" g="<%= @base["0C"]["rgb"][1] %>" b="<%= @base["0C"]["rgb"][2] %>"/>
-			<color id="4" r="<%= @base["08"]["rgb"][0] %>" g="<%= @base["08"]["rgb"][1] %>" b="<%= @base["08"]["rgb"][2] %>"/>
-			<color id="5" r="<%= @base["0E"]["rgb"][0] %>" g="<%= @base["0E"]["rgb"][1] %>" b="<%= @base["0E"]["rgb"][2] %>"/>
-			<color id="6" r="<%= @base["0A"]["rgb"][0] %>" g="<%= @base["0A"]["rgb"][1] %>" b="<%= @base["0A"]["rgb"][2] %>"/>
-			<color id="7" r="<%= @base["05"]["rgb"][0] %>" g="<%= @base["05"]["rgb"][1] %>" b="<%= @base["05"]["rgb"][2] %>"/>
-			<color id="8" r="<%= @base["03"]["rgb"][0] %>" g="<%= @base["03"]["rgb"][1] %>" b="<%= @base["03"]["rgb"][2] %>"/>
-			<color id="9" r="<%= @base["04"]["rgb"][0] %>" g="<%= @base["04"]["rgb"][1] %>" b="<%= @base["04"]["rgb"][2] %>"/>
-			<color id="10" r="<%= @base["01"]["rgb"][0] %>" g="<%= @base["01"]["rgb"][1] %>" b="<%= @base["01"]["rgb"][2] %>"/>
-			<color id="11" r="<%= @base["0F"]["rgb"][0] %>" g="<%= @base["0F"]["rgb"][1] %>" b="<%= @base["0F"]["rgb"][2] %>"/>
-			<color id="12" r="<%= @base["09"]["rgb"][0] %>" g="<%= @base["09"]["rgb"][1] %>" b="<%= @base["09"]["rgb"][2] %>"/>
-			<color id="13" r="<%= @base["06"]["rgb"][0] %>" g="<%= @base["06"]["rgb"][1] %>" b="<%= @base["06"]["rgb"][2] %>"/>
-			<color id="14" r="<%= @base["02"]["rgb"][0] %>" g="<%= @base["02"]["rgb"][1] %>" b="<%= @base["02"]["rgb"][2] %>"/>
-			<color id="15" r="<%= @base["07"]["rgb"][0] %>" g="<%= @base["07"]["rgb"][1] %>" b="<%= @base["07"]["rgb"][2] %>"/>
+			<color id="0" r="<%= @terminal_colors[:black]["rgb"][0] %>" g="<%= @terminal_colors[:black]["rgb"][1] %>" b="<%= @terminal_colors[:black]["rgb"][2] %>"/>
+			<color id="1" r="<%= @terminal_colors[:blue]["rgb"][0] %>" g="<%= @terminal_colors[:blue]["rgb"][1] %>" b="<%= @terminal_colors[:blue]["rgb"][2] %>"/>
+			<color id="2" r="<%= @terminal_colors[:green]["rgb"][0] %>" g="<%= @terminal_colors[:green]["rgb"][1] %>" b="<%= @terminal_colors[:green]["rgb"][2] %>"/>
+			<color id="3" r="<%= @terminal_colors[:cyan]["rgb"][0] %>" g="<%= @terminal_colors[:cyan]["rgb"][1] %>" b="<%= @terminal_colors[:cyan]["rgb"][2] %>"/>
+			<color id="4" r="<%= @terminal_colors[:red]["rgb"][0] %>" g="<%= @terminal_colors[:red]["rgb"][1] %>" b="<%= @terminal_colors[:red]["rgb"][2] %>"/>
+			<color id="5" r="<%= @terminal_colors[:magenta]["rgb"][0] %>" g="<%= @terminal_colors[:magenta]["rgb"][1] %>" b="<%= @terminal_colors[:magenta]["rgb"][2] %>"/>
+			<color id="6" r="<%= @terminal_colors[:yellow]["rgb"][0] %>" g="<%= @terminal_colors[:yellow]["rgb"][1] %>" b="<%= @terminal_colors[:yellow]["rgb"][2] %>"/>
+			<color id="7" r="<%= @terminal_colors[:white]["rgb"][0] %>" g="<%= @terminal_colors[:white]["rgb"][1] %>" b="<%= @terminal_colors[:white]["rgb"][2] %>"/>
+			<color id="8" r="<%= @terminal_colors[:bright_black]["rgb"][0] %>" g="<%= @terminal_colors[:bright_black]["rgb"][1] %>" b="<%= @terminal_colors[:bright_black]["rgb"][2] %>"/>
+			<color id="9" r="<%= @terminal_colors[:bright_blue]["rgb"][0] %>" g="<%= @terminal_colors[:bright_blue]["rgb"][1] %>" b="<%= @terminal_colors[:bright_blue]["rgb"][2] %>"/>
+			<color id="10" r="<%= @terminal_colors[:bright_green]["rgb"][0] %>" g="<%= @terminal_colors[:bright_green]["rgb"][1] %>" b="<%= @terminal_colors[:bright_green]["rgb"][2] %>"/>
+			<color id="11" r="<%= @terminal_colors[:bright_cyan]["rgb"][0] %>" g="<%= @terminal_colors[:bright_cyan]["rgb"][1] %>" b="<%= @terminal_colors[:bright_cyan]["rgb"][2] %>"/>
+			<color id="12" r="<%= @terminal_colors[:bright_red]["rgb"][0] %>" g="<%= @terminal_colors[:bright_red]["rgb"][1] %>" b="<%= @terminal_colors[:bright_red]["rgb"][2] %>"/>
+			<color id="13" r="<%= @terminal_colors[:bright_magenta]["rgb"][0] %>" g="<%= @terminal_colors[:bright_magenta]["rgb"][1] %>" b="<%= @terminal_colors[:bright_magenta]["rgb"][2] %>"/>
+			<color id="14" r="<%= @terminal_colors[:bright_yellow]["rgb"][0] %>" g="<%= @terminal_colors[:bright_yellow]["rgb"][1] %>" b="<%= @terminal_colors[:bright_yellow]["rgb"][2] %>"/>
+			<color id="15" r="<%= @terminal_colors[:bright_white]["rgb"][0] %>" g="<%= @terminal_colors[:bright_white]["rgb"][1] %>" b="<%= @terminal_colors[:bright_white]["rgb"][2] %>"/>
 		</colors>
 	</console>
 </settings>


### PR DESCRIPTION
The map is an abstraction of the base16 colors for terminal templates.  The standard ANSI/win32 palette is mapped to an appropriate base16 color.  This should help with consistency between terminal templates.

I've only changed the console2 templates to use the new map so far.
