### PR TITLE
OSX Terminal templates for dark{,256}, light{,256}

### DIFF
--- a/templates/terminal-app/dark.256.terminal.erb
+++ b/templates/terminal-app/dark.256.terminal.erb
@@ -1,110 +1,63 @@
 <%
-# Terminal.app Template
-# Petr Hosek (http://petrhosek.name)
-bplist = "bplist00\xD4\x01\x02\x03\x04\x05\x06\x15\x16X$versionX$objectsY$archiverT$top\x12\x00\x01\x86\xA0\xA3\a\b\x0FU$null\xD3\t\n\v\f\r\x0EUNSRGB\\NSColorSpaceV$classO\x10'%.10f %.10f %.10f\x00\x10\x01\x80\x02\xD2\x10\x11\x12\x13Z$classnameX$classesWNSColor\xA2\x12\x14XNSObject_\x10\x0FNSKeyedArchiver\xD1\x17\x18Troot\x80\x01\b\x11\x1A#-27;AHN[b\x8C\x8E\x90\x95\xA0\xA9\xB1\xB4\xBD\xCF\xD2\xD7\x00\x00\x00\x00\x00\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x19\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xD9"
+bplist = "bplist00\xD4\x01\x02\x03\x04\x05\x06\x15\x16X$versionX$objectsY"\
+         "$archiverT$top\x12\x00\x01\x86\xA0\xA3\a\b\x0FU$null\xD3\t\n\v\f"\
+         "\r\x0EUNSRGB\\NSColorSpaceV$classO\x10,%.10f %.10f %.10f %.2f\x00"\
+         "\x10\x02\x80\x02\xD2\x10\x11\x12\x13Z$classnameX$classesWNSColor"\
+         "\xA2\x12\x14XNSObject_\x10\x0FNSKeyedArchiver\xD1\x17\x18Troot"\
+         "\x80\x01\b\x11\x1A#-27;AHN[b\x91\x93\x95\x9A\xA5\xAE\xB6\xB9\xC2"\
+         "\xD4\xD7\xDC\x00\x00\x00\x00\x00\x00\x01\x01\x00\x00\x00\x00\x00"\
+         "\x00\x00\x19\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"\
+         "\x00\x00\xDE"
+
+color_keys = {
+    'ANSIBlackColor' => '00',
+    'ANSIRedColor' => '08',
+    'ANSIGreenColor' => '0B',
+    'ANSIYellowColor' => '0A',
+    'ANSIBlueColor' => '0D',
+    'ANSIMagentaColor' => '0E',
+    'ANSICyanColor' => '0C',
+    'ANSIWhiteColor' => '05',
+
+    'ANSIBrightBlackColor' => '03',
+    'ANSIBrightRedColor' => '08',
+    'ANSIBrightGreenColor' => '0B',
+    'ANSIBrightYellowColor' => '0A',
+    'ANSIBrightBlueColor' => '0D',
+    'ANSIBrightMagentaColor' => '0E',
+    'ANSIBrightCyanColor' => '0C',
+    'ANSIBrightWhiteColor' => '07',
+
+    'BackgroundColor' => '00',
+    'CursorColor' => '05',
+    'SelectionColor' => '03',
+    'TextBoldColor' => '05',
+    'TextColor' => '05',
+}
+
 %><?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ANSIBlackColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["00"]["srgb"][0], @base["00"]["srgb"][1], @base["00"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBlueColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0D"]["srgb"][0], @base["0D"]["srgb"][1], @base["0D"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightBlackColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["03"]["srgb"][0], @base["03"]["srgb"][1], @base["03"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightBlueColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0D"]["srgb"][0], @base["0D"]["srgb"][1], @base["0D"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightCyanColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0C"]["srgb"][0], @base["0C"]["srgb"][1], @base["0C"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightGreenColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0B"]["srgb"][0], @base["0B"]["srgb"][1], @base["0B"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightMagentaColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0E"]["srgb"][0], @base["0E"]["srgb"][1], @base["0E"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightRedColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["08"]["srgb"][0], @base["08"]["srgb"][1], @base["08"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightWhiteColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["07"]["srgb"][0], @base["07"]["srgb"][1], @base["07"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIBrightYellowColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0A"]["srgb"][0], @base["0A"]["srgb"][1], @base["0A"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSICyanColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0C"]["srgb"][0], @base["0C"]["srgb"][1], @base["0C"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIGreenColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0B"]["srgb"][0], @base["0B"]["srgb"][1], @base["0B"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIMagentaColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0E"]["srgb"][0], @base["0E"]["srgb"][1], @base["0E"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIRedColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["08"]["srgb"][0], @base["08"]["srgb"][1], @base["08"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIWhiteColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["05"]["srgb"][0], @base["05"]["srgb"][1], @base["05"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>ANSIYellowColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["0A"]["srgb"][0], @base["0A"]["srgb"][1], @base["0A"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>BackgroundColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["00"]["srgb"][0], @base["00"]["srgb"][1], @base["00"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>CursorColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["05"]["srgb"][0], @base["05"]["srgb"][1], @base["05"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>FontAntialias</key>
-	<true/>
-	<key>FontWidthSpacing</key>
-	<real>0.99596774193548387</real>
-	<key>Linewrap</key>
-	<true/>
-	<key>ProfileCurrentVersion</key>
-	<real>2.02</real>
-	<key>SelectionColor</key>
-	<data>
-    <%= Base64.encode64(sprintf(bplist, @base["03"]["srgb"][0], @base["03"]["srgb"][1], @base["03"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-    </data>
-	<key>TextBoldColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["05"]["srgb"][0], @base["05"]["srgb"][1], @base["05"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>TextColor</key>
-	<data>
-	<%= Base64.encode64(sprintf(bplist, @base["05"]["srgb"][0], @base["05"]["srgb"][1], @base["05"]["srgb"][2])).gsub("\n", "\n\t").strip %>
-	</data>
-	<key>UseBrightBold</key>
-	<false/>
 	<key>name</key>
-	<string>Base 16 <%= @scheme %></string>
-	<key>shellExitAction</key>
-	<integer>1</integer>
+	<string><%= @scheme %></string>
+
 	<key>type</key>
 	<string>Window Settings</string>
+
+	<key>UseBrightBold</key>
+	<false/>
+<% color_keys.each do |name, hex| %>
+        <key><%= name %></key>
+	<data>
+        <%= Base64.encode64(sprintf(bplist,
+                                    @base[hex]["srgb"][0],
+                                    @base[hex]["srgb"][1],
+                                    @base[hex]["srgb"][2],
+                                    1)
+                           ).gsub("\n", "\n\t").strip %>
+	</data>
+<% end %>
 </dict>
 </plist>

--- a/templates/terminal-app/light.256.terminal.erb
+++ b/templates/terminal-app/light.256.terminal.erb
@@ -20,19 +20,19 @@ color_keys = {
     'ANSIWhiteColor' => '05',
 
     'ANSIBrightBlackColor' => '03',
-    'ANSIBrightRedColor' => '09',
-    'ANSIBrightGreenColor' => '01',
-    'ANSIBrightYellowColor' => '02',
-    'ANSIBrightBlueColor' => '04',
-    'ANSIBrightMagentaColor' => '06',
-    'ANSIBrightCyanColor' => '0F',
+    'ANSIBrightRedColor' => '08',
+    'ANSIBrightGreenColor' => '0B',
+    'ANSIBrightYellowColor' => '0A',
+    'ANSIBrightBlueColor' => '0D',
+    'ANSIBrightMagentaColor' => '0E',
+    'ANSIBrightCyanColor' => '0C',
     'ANSIBrightWhiteColor' => '07',
 
-    'BackgroundColor' => '00',
-    'CursorColor' => '05',
-    'SelectionColor' => '03',
-    'TextBoldColor' => '05',
-    'TextColor' => '05',
+    'BackgroundColor' => '07',
+    'CursorColor' => '02',
+    'SelectionColor' => '05',
+    'TextBoldColor' => '02',
+    'TextColor' => '02',
 }
 
 %><?xml version="1.0" encoding="UTF-8"?>

--- a/templates/terminal-app/light.terminal.erb
+++ b/templates/terminal-app/light.terminal.erb
@@ -28,11 +28,11 @@ color_keys = {
     'ANSIBrightCyanColor' => '0F',
     'ANSIBrightWhiteColor' => '07',
 
-    'BackgroundColor' => '00',
-    'CursorColor' => '05',
-    'SelectionColor' => '03',
-    'TextBoldColor' => '05',
-    'TextColor' => '05',
+    'BackgroundColor' => '07',
+    'CursorColor' => '02',
+    'SelectionColor' => '05',
+    'TextBoldColor' => '02',
+    'TextColor' => '02',
 }
 
 %><?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Adds in the light variation that was missing before. Templates use a
loop instead of stating each colour individually so should simplify
maintainence.
