### PR TITLE
Re-add missing colors 01, 02, 04, 06, 09, and 0F to Gnome Terminal Dark template

### DIFF
--- a/templates/gnome-terminal/dark.sh.erb
+++ b/templates/gnome-terminal/dark.sh.erb
@@ -63,7 +63,7 @@ if which "$DCONF" > /dev/null 2>&1; then
 
         # update profile values with theme options
         dset visible-name "'$PROFILE_NAME'"
-        dset palette "['#<%= @base["00"]["hex"] %>', '#<%= @base["08"]["hex"] %>', '#<%= @base["0B"]["hex"] %>', '#<%= @base["0A"]["hex"] %>', '#<%= @base["0D"]["hex"] %>', '#<%= @base["0E"]["hex"] %>', '#<%= @base["0C"]["hex"] %>', '#<%= @base["05"]["hex"] %>', '#<%= @base["03"]["hex"] %>', '#<%= @base["08"]["hex"] %>', '#<%= @base["0B"]["hex"] %>', '#<%= @base["0A"]["hex"] %>', '#<%= @base["0D"]["hex"] %>', '#<%= @base["0E"]["hex"] %>', '#<%= @base["0C"]["hex"] %>', '#<%= @base["07"]["hex"] %>']"
+        dset palette "['#<%= @base["00"]["hex"] %>', '#<%= @base["08"]["hex"] %>', '#<%= @base["0B"]["hex"] %>', '#<%= @base["0A"]["hex"] %>', '#<%= @base["0D"]["hex"] %>', '#<%= @base["0E"]["hex"] %>', '#<%= @base["0C"]["hex"] %>', '#<%= @base["05"]["hex"] %>', '#<%= @base["03"]["hex"] %>', '#<%= @base["09"]["hex"] %>', '#<%= @base["01"]["hex"] %>', '#<%= @base["02"]["hex"] %>', '#<%= @base["04"]["hex"] %>', '#<%= @base["06"]["hex"] %>', '#<%= @base["0F"]["hex"] %>', '#<%= @base["07"]["hex"] %>']"
         dset background-color "'#<%= @base["00"]["hex"] %>'"
         dset foreground-color "'#<%= @base["05"]["hex"] %>'"
         dset bold-color "'#<%= @base["05"]["hex"] %>'"
@@ -113,7 +113,7 @@ glist_append() {
 glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
 
 gset string visible_name "$PROFILE_NAME"
-gset string palette "#<%= @base["00"]["hex"] %>:#<%= @base["08"]["hex"] %>:#<%= @base["0B"]["hex"] %>:#<%= @base["0A"]["hex"] %>:#<%= @base["0D"]["hex"] %>:#<%= @base["0E"]["hex"] %>:#<%= @base["0C"]["hex"] %>:#<%= @base["05"]["hex"] %>:#<%= @base["03"]["hex"] %>:#<%= @base["08"]["hex"] %>:#<%= @base["0B"]["hex"] %>:#<%= @base["0A"]["hex"] %>:#<%= @base["0D"]["hex"] %>:#<%= @base["0E"]["hex"] %>:#<%= @base["0C"]["hex"] %>:#<%= @base["07"]["hex"] %>"
+gset string palette "#<%= @base["00"]["hex"] %>:#<%= @base["08"]["hex"] %>:#<%= @base["0B"]["hex"] %>:#<%= @base["0A"]["hex"] %>:#<%= @base["0D"]["hex"] %>:#<%= @base["0E"]["hex"] %>:#<%= @base["0C"]["hex"] %>:#<%= @base["05"]["hex"] %>:#<%= @base["03"]["hex"] %>:#<%= @base["09"]["hex"] %>:#<%= @base["01"]["hex"] %>:#<%= @base["02"]["hex"] %>:#<%= @base["04"]["hex"] %>:#<%= @base["06"]["hex"] %>:#<%= @base["0F"]["hex"] %>:#<%= @base["07"]["hex"] %>"
 gset string background_color "#<%= @base["00"]["hex"] %>"
 gset string foreground_color "#<%= @base["05"]["hex"] %>"
 gset string bold_color "#<%= @base["05"]["hex"] %>"


### PR DESCRIPTION
This is intended to resolve issue https://github.com/chriskempson/base16-builder/issues/179 for Gnome Terminal Dark. It re-adds missing colors 01, 02, 04, 06, 09, and 0F, which were removed (perhaps inadvertently) in a previous commit (307572).

Please note I have not submitted a fix for Gnome Terminal Light because I don't use/test that scheme, but I suspect almost identical fix should apply.