### PR TITLE
use base0A for brace_good in dark themes in Geany

### DIFF
--- a/templates/geany/dark.conf.erb
+++ b/templates/geany/dark.conf.erb
@@ -36,7 +36,7 @@ error=#<%= @base["08"]["hex"] %>
 #-------------------------------------------------------------------------------
 selection=#<%= @base["04"]["hex"] %>;#<%= @base["03"]["hex"] %>;false;true
 current_line=;#<%= @base["02"]["hex"] %>;true;false
-brace_good=#<%= @base["0B"]["hex"] %>;;true;false
+brace_good=#<%= @base["0A"]["hex"] %>;;true;false
 brace_bad=#<%= @base["08"]["hex"] %>;#<%= @base["02"]["hex"] %>;true;false
 margin_line_number=#<%= @base["03"]["hex"] %>;#<%= @base["02"]["hex"] %>;true;false
 margin_folding=#<%= @base["03"]["hex"] %>


### PR DESCRIPTION
This commit changes the color for  `brace_good` in https://github.com/chriskempson/base16-builder/blob/master/templates/geany/dark.conf.erb from  `base0B`  to  `base0A`. This improves contrast, thus allows for much easier spotting and following of braces. 

This change was already discussed here: 
https://github.com/RobLoach/base16-geany/issues/7