### PR TITLE
Better C# highlighting support in Vim

### DIFF
--- a/templates/vim/vim.erb
+++ b/templates/vim/vim.erb
@@ -215,6 +215,15 @@ call <sid>hi("Typedef",      s:gui0A, "", s:cterm0A, "", "")
 call <sid>hi("cOperator",   s:gui0C, "", s:cterm0C, "", "")
 call <sid>hi("cPreCondit",  s:gui0E, "", s:cterm0E, "", "")
 
+" C# highlighting
+call <sid>hi("csClass",                 s:gui0A, "", s:cterm0A, "", "")
+call <sid>hi("csAttribute",             s:gui0A, "", s:cterm0A, "", "")
+call <sid>hi("csModifier",              s:gui0E, "", s:cterm0E, "", "")
+call <sid>hi("csType",                  s:gui08, "", s:cterm08, "", "")
+call <sid>hi("csUnspecifiedStatement",  s:gui0D, "", s:cterm0D, "", "")
+call <sid>hi("csContextualStatement",   s:gui0E, "", s:cterm0E, "", "")
+call <sid>hi("csNewDecleration",        s:gui08, "", s:cterm08, "", "")
+
 " CSS highlighting
 call <sid>hi("cssBraces",      s:gui05, "", s:cterm05, "", "")
 call <sid>hi("cssClassName",   s:gui0E, "", s:cterm0E, "", "")


### PR DESCRIPTION
Added better highlighting support for C# files in VIM. Better results are
obtained when using an updated C# syntax file like
https://github.com/OrangeT/vim-csharp