### PR TITLE
shell: change cursor to use reverse video

### DIFF
--- a/templates/shell/dark.sh.erb
+++ b/templates/shell/dark.sh.erb
@@ -92,7 +92,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 
 # clean up

--- a/templates/shell/light.sh.erb
+++ b/templates/shell/light.sh.erb
@@ -92,7 +92,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
 else
   printf $printf_template_var 10 $color_foreground
   printf $printf_template_var 11 $color_background
-  printf $printf_template_var 12 $color_cursor
+  printf $printf_template_custom 12 ";7" # cursor (reverse video)
 fi
 
 # clean up


### PR DESCRIPTION
This fixes the issue filed for base16-shell [here](https://github.com/chriskempson/base16-shell/issues/30)

Let me know if there's a better way to fix this. I didn't make the change for iterm because I'm not on a mac right now.