### PR TITLE
Add an .scss-file to templates.

### DIFF
--- a/templates/scss/scss.erb
+++ b/templates/scss/scss.erb
@@ -1,0 +1,19 @@
+// Base 16 <%= @scheme %>
+// Colors by <%= @author %>
+// Built with: https://github.com/chriskempson/base16-builder
+$base16-color-00: #<%= @base["00"]["hex"] %>;
+$base16-color-01: #<%= @base["01"]["hex"] %>;
+$base16-color-02: #<%= @base["02"]["hex"] %>;
+$base16-color-03: #<%= @base["03"]["hex"] %>;
+$base16-color-04: #<%= @base["04"]["hex"] %>;
+$base16-color-05: #<%= @base["05"]["hex"] %>;
+$base16-color-06: #<%= @base["06"]["hex"] %>;
+$base16-color-07: #<%= @base["07"]["hex"] %>;
+$base16-color-08: #<%= @base["08"]["hex"] %>;
+$base16-color-09: #<%= @base["09"]["hex"] %>;
+$base16-color-0a: #<%= @base["0A"]["hex"] %>;
+$base16-color-0b: #<%= @base["0B"]["hex"] %>;
+$base16-color-0c: #<%= @base["0C"]["hex"] %>;
+$base16-color-0d: #<%= @base["0D"]["hex"] %>;
+$base16-color-0e: #<%= @base["0E"]["hex"] %>;
+$base16-color-0f: #<%= @base["0F"]["hex"] %>;


### PR DESCRIPTION
I have based a couple of websites on base16 color schemes. For that I have made simple .scss-files with all colors as variables.

There is no light/dark since it is just the colors as variables.

Here is a sample output file:
```SCSS
// Base 16 Ashes
// Colors by Jannik Siebert (https://github.com/janniks)
// Built with: https://github.com/chriskempson/base16-builder
$base16-color-00: #1C2023;
$base16-color-01: #393F45;
$base16-color-02: #565E65;
$base16-color-03: #747C84;
$base16-color-04: #ADB3BA;
$base16-color-05: #C7CCD1;
$base16-color-06: #DFE2E5;
$base16-color-07: #F3F4F5;
$base16-color-08: #C7AE95;
$base16-color-09: #C7C795;
$base16-color-0a: #AEC795;
$base16-color-0b: #95C7AE;
$base16-color-0c: #95AEC7;
$base16-color-0d: #AE95C7;
$base16-color-0e: #C795AE;
$base16-color-0f: #C79595;
```