### PR TITLE
Avoid the wrapping of code lines in Prism

### DIFF
--- a/templates/prism/dark.css.erb
+++ b/templates/prism/dark.css.erb
@@ -6,17 +6,18 @@ Author:     <%= @author %>
 Prism template by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/prism/)
 Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
 
- */ 
+*/
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #<%= @base["07"]["hex"] %>;
   font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
   font-size: 14px;
   line-height: 1.375;
   direction: ltr;
   text-align: left;
+  white-space: pre;
   word-spacing: normal;
+  word-break: normal;
 
   -moz-tab-size: 4;
   -o-tab-size: 4;
@@ -25,20 +26,28 @@ pre[class*="language-"] {
   -webkit-hyphens: none;
   -moz-hyphens: none;
   -ms-hyphens: none;
-  hyphens: none; 
-  white-space: pre; 
-  white-space: pre-wrap; 
-  word-break: break-all;
-  word-wrap: break-word; 
-  background: #<%= @base["00"]["hex"] %>; 
+  hyphens: none;
+  background: #<%= @base["00"]["hex"] %>;
   color: #<%= @base["05"]["hex"] %>;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+  text-shadow: none;
+  background: #<%= @base["04"]["hex"] %>;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+  text-shadow: none;
+  background: #<%= @base["04"]["hex"] %>;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
   padding: 1em;
   margin: .5em 0;
-  overflow: auto;	
+  overflow: auto;
 }
 
 /* Inline code */
@@ -67,24 +76,24 @@ pre[class*="language-"] {
 .token.boolean,
 .token.number {
   color: #<%= @base["09"]["hex"] %>;
-} 
-.token.property { 
+}
+.token.property {
   color: #<%= @base["0A"]["hex"] %>;
 }
-.token.tag { 
+.token.tag {
   color: #<%= @base["0D"]["hex"] %>;
-} 
+}
 .token.string {
   color: #<%= @base["0C"]["hex"] %>;
-} 
-.token.selector { 
+}
+.token.selector {
   color: #<%= @base["0E"]["hex"] %>;
 }
-.token.attr-name { 
+.token.attr-name {
   color: #<%= @base["09"]["hex"] %>;
-} 
+}
 .token.entity,
-.token.url, 
+.token.url,
 .language-css .token.string,
 .style .token.string {
   color: #<%= @base["0C"]["hex"] %>;
@@ -96,30 +105,29 @@ pre[class*="language-"] {
 .token.directive,
 .token.unit {
   color: #<%= @base["0B"]["hex"] %>;
-} 
+}
 
 .token.statement,
-.token.regex, 
-.token.atrule { 
+.token.regex,
+.token.atrule {
   color: #<%= @base["0C"]["hex"] %>;
 }
 
 .token.placeholder,
 .token.variable {
   color: #<%= @base["0D"]["hex"] %>;
-} 
+}
 
 .token.important {
   color: #<%= @base["08"]["hex"] %>;
   font-weight: bold;
-} 
+}
 
 .token.entity {
   cursor: help;
-} 
+}
 
 pre > code.highlight {
-  outline: .4em solid red;
+  outline: .4em solid #<%= @base["08"]["hex"] %>;
   outline-offset: .4em;
-} 
-
+}

--- a/templates/prism/light.css.erb
+++ b/templates/prism/light.css.erb
@@ -6,17 +6,18 @@ Author:     <%= @author %>
 Prism template by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/prism/)
 Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
 
- */ 
+*/
 
 code[class*="language-"],
 pre[class*="language-"] {
-  color: #<%= @base["07"]["hex"] %>;
   font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
   font-size: 14px;
   line-height: 1.375;
   direction: ltr;
   text-align: left;
+  white-space: pre;
   word-spacing: normal;
+  word-break: normal;
 
   -moz-tab-size: 4;
   -o-tab-size: 4;
@@ -25,20 +26,28 @@ pre[class*="language-"] {
   -webkit-hyphens: none;
   -moz-hyphens: none;
   -ms-hyphens: none;
-  hyphens: none; 
-  white-space: pre; 
-  white-space: pre-wrap; 
-  word-break: break-all;
-  word-wrap: break-word; 
-  background: #<%= @base["07"]["hex"] %>; 
+  hyphens: none;
+  background: #<%= @base["07"]["hex"] %>;
   color: #<%= @base["02"]["hex"] %>;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+  text-shadow: none;
+  background: #<%= @base["06"]["hex"] %>;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+  text-shadow: none;
+  background: #<%= @base["06"]["hex"] %>;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
   padding: 1em;
   margin: .5em 0;
-  overflow: auto;	
+  overflow: auto;
 }
 
 /* Inline code */
@@ -67,24 +76,24 @@ pre[class*="language-"] {
 .token.boolean,
 .token.number {
   color: #<%= @base["09"]["hex"] %>;
-} 
-.token.property { 
+}
+.token.property {
   color: #<%= @base["0A"]["hex"] %>;
 }
-.token.tag { 
+.token.tag {
   color: #<%= @base["0D"]["hex"] %>;
-} 
+}
 .token.string {
   color: #<%= @base["0C"]["hex"] %>;
-} 
-.token.selector { 
+}
+.token.selector {
   color: #<%= @base["0E"]["hex"] %>;
 }
-.token.attr-name { 
+.token.attr-name {
   color: #<%= @base["09"]["hex"] %>;
-} 
+}
 .token.entity,
-.token.url, 
+.token.url,
 .language-css .token.string,
 .style .token.string {
   color: #<%= @base["0C"]["hex"] %>;
@@ -96,30 +105,29 @@ pre[class*="language-"] {
 .token.directive,
 .token.unit {
   color: #<%= @base["0B"]["hex"] %>;
-} 
+}
 
 .token.statement,
-.token.regex, 
-.token.atrule { 
+.token.regex,
+.token.atrule {
   color: #<%= @base["0C"]["hex"] %>;
 }
 
 .token.placeholder,
 .token.variable {
   color: #<%= @base["0D"]["hex"] %>;
-} 
+}
 
 .token.important {
   color: #<%= @base["08"]["hex"] %>;
   font-weight: bold;
-} 
+}
 
 .token.entity {
   cursor: help;
-} 
+}
 
 pre > code.highlight {
-  outline: .4em solid red;
+  outline: .4em solid #<%= @base["08"]["hex"] %>;
   outline-offset: .4em;
-} 
-
+}


### PR DESCRIPTION
- Avoid the wrapping of code lines; letting it default to a horizontal scrollbar on the container, for it gives a more accurate representation of the written code, without those clumsy line-breaks. This behaves the same now as on the original default theme of Prism. See also [this demo](http://atelierbram.github.io/syntax-highlighting/prism/).
- Let the background-color of **selected** syntax-highlighted code also be a colorscheme color, to be able to override the globally defined one (, or browser’s default). _(This follows a recent addition to the original repo)_.
Let `code.hightlight` also be a colorscheme color, instead of “colorname red” (`#f00`), here: `base08`
- removed the excess _(double)_ property/value pair for color on first declaration, _(which I failed to notice before)_.  
- Removed empty white-space characters