### PR TITLE
Add Yesterday color schemes

### DIFF
--- a/schemes/yesterday-bright.yml
+++ b/schemes/yesterday-bright.yml
@@ -1,0 +1,22 @@
+# Based on the original and current Tomorrow themes by Chris Kempson
+# [1] tomorrow.yml
+# [2] https://github.com/chriskempson/tomorrow-theme
+# [3] ocean.yml
+scheme: "Yesterday Bright"
+author: "FroZnShiva (https://github.com/FroZnShiva)"
+base00: "343d46" # [3] Gray1
+base01: "4f5b66" # [3] Gray2
+base02: "65737e" # [3] Gray3
+base03: "a7adba" # [3] Gray4
+base04: "c0c5ce" # [3] Gray5
+base05: "dfe1e8" # [3] Gray6
+base06: "eff1f5" # [3] Gray7
+base07: "ffffff" # [1] Gray7
+base08: "d54e53" # [2] Red
+base09: "e78c45" # [2] Orange
+base0A: "e7c547" # [2] Yellow
+base0B: "b9ca4a" # [2] Green
+base0C: "70c0b1" # [2] Aqua
+base0D: "7aa6da" # [2] Blue
+base0E: "c397d8" # [2] Purple
+base0F: "9a806d" #     Brown: 0xa3685a - ( 0xd54e53 - 0xcc6666 )

--- a/schemes/yesterday-night.yml
+++ b/schemes/yesterday-night.yml
@@ -1,0 +1,22 @@
+# Based on the Tomorrow and Ocean themes by Chris Kempson
+# [1] tomorrow.yml
+# [2] ocean.yml
+# Tomorrow is based on the original Tomorrow Night theme, hence the Name
+scheme: "Yesterday Night"
+author: "FroZnShiva (https://github.com/FroZnShiva)"
+base00: "343d46" # [2] Gray1
+base01: "4f5b66" # [2] Gray2
+base02: "65737e" # [2] Gray3
+base03: "a7adba" # [2] Gray4
+base04: "c0c5ce" # [2] Gray5
+base05: "dfe1e8" # [2] Gray6
+base06: "eff1f5" # [2] Gray7
+base07: "ffffff" # [1] Foreground
+base08: "cc6666" # [1] Red
+base09: "de935f" # [1] Orange
+base0A: "f0c674" # [1] Yellow
+base0B: "b5bd68" # [1] Green
+base0C: "8abeb7" # [1] Aqua
+base0D: "81a2be" # [1] Blue
+base0E: "b294bb" # [1] Purple
+base0F: "a3685a" # [1] Brown

--- a/schemes/yesterday.yml
+++ b/schemes/yesterday.yml
@@ -1,0 +1,21 @@
+# Based on the original and current Tomorrow themes by Chris Kempson
+# [1] tomorrow.yml
+# [2] https://github.com/chriskempson/tomorrow-theme
+scheme: "Yesterday"
+author: "FroZnShiva (https://github.com/FroZnShiva)"
+base00: "1d1f21" # [1]   Gray0
+base01: "282a2e" # [1]   Gray1
+base02: "4d4d4c" # [2]   Foreground
+base03: "969896" # [1]   Gray3
+base04: "8e908c" # [2]   Comment
+base05: "d6d6d6" # [2]   Selection
+base06: "efefef" # [2]   Current Line
+base07: "ffffff" # [1,2] Gray7, Background
+base08: "c82829" # [2]   Red
+base09: "f5871f" # [2]   Orange
+base0A: "eab700" # [2]   Yellow
+base0B: "718c00" # [2]   Green
+base0C: "3e999f" # [2]   Aqua
+base0D: "4271ae" # [2]   Blue
+base0E: "8959a8" # [2]   Purple
+base0F: "7f2a1d" #       Brown:  0xa3+0xc8-0xcc-0x20 . 0x68+0x28-0x66 . 0x5a+0x29-0x66


### PR DESCRIPTION
The Yesterday color schemes are basically some of the [old (pre-base16) Tomorrow
color schemes](https://github.com/chriskempson/tomorrow-theme) which were missing.
For Yesterday Night and Yesterday Bright I've chosen to lighten up the
background colours a bit.

The mapping is as following (including existing schemes):

  Base16 | Tomorrow
  ------ | --------
  Tomorrow | Tomorrow Night
  Eighties | Tomorrow Night Eighties
  *none* | Tomorrow Night Blue
  Yesterday | Tomorrow
  Yesterday Night | Tomorrow Night + lighter background (from Ocean)
  Yesterday Bright | Tomorrow Night Bright + lighter background (from Ocean)

You can see them in action (alas not for code):
* [Yesterday](https://github.com/FroZnShiva/base16-textual#base16-yesterday)
* [Yesterday Bright](https://github.com/FroZnShiva/base16-textual#base16-yesterday-bright)
* [Yesterday Night](https://github.com/FroZnShiva/base16-textual#base16-yesterday-night)