### PR TITLE
Fix atom templates

### DIFF
--- a/templates/atom/-dark-base.less.erb
+++ b/templates/atom/-dark-base.less.erb
@@ -147,7 +147,7 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
   color: #<%= @base["09"]["hex"] %>;
 }
 
-.markup.heading .punctuation.definition.heading, .entity.name.section {
+.markup.heading, .punctuation.definition.heading, .entity.name.section {
   color: #<%= @base["0D"]["hex"] %>;
 }
 

--- a/templates/atom/-light-base.less.erb
+++ b/templates/atom/-light-base.less.erb
@@ -148,7 +148,7 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
   color: #<%= @base["09"]["hex"] %>;
 }
 
-.markup.heading .punctuation.definition.heading, .entity.name.section {
+.markup.heading, .punctuation.definition.heading, .entity.name.section {
   color: #<%= @base["0D"]["hex"] %>;
 }
 


### PR DESCRIPTION
I found that Markdown headings were not getting rendered in an alternate color as they were intended to. It looks like there are unintentionally missing commas from the `.markup.heading` selectors in the Atom theme.

@idleberg let me know if I’ve got this wrong (and thanks for your work on the Atom template!).