### PR TITLE
xresources: remove useless period character

### DIFF
--- a/templates/xresources/dark.256.xresources.erb
+++ b/templates/xresources/dark.256.xresources.erb
@@ -22,33 +22,33 @@
 #define base0E #<%= @base["0E"]["hex"] %>
 #define base0F #<%= @base["0F"]["hex"] %>
 
-*.foreground:   base05
-*.background:   base00
-*.cursorColor:  base05
+*foreground:   base05
+*background:   base00
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/templates/xresources/dark.xresources.erb
+++ b/templates/xresources/dark.xresources.erb
@@ -22,24 +22,24 @@
 #define base0E #<%= @base["0E"]["hex"] %>
 #define base0F #<%= @base["0F"]["hex"] %>
 
-*.foreground:   base05
-*.background:   base00
-*.cursorColor:  base05
+*foreground:   base05
+*background:   base00
+*cursorColor:  base05
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07

--- a/templates/xresources/light.256.xresources.erb
+++ b/templates/xresources/light.256.xresources.erb
@@ -22,33 +22,33 @@
 #define base0E #<%= @base["0E"]["hex"] %>
 #define base0F #<%= @base["0F"]["hex"] %>
 
-*.foreground:   base02
-*.background:   base07
-*.cursorColor:  base02
+*foreground:   base02
+*background:   base07
+*cursorColor:  base02
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base08
-*.color10:      base0B
-*.color11:      base0A
-*.color12:      base0D
-*.color13:      base0E
-*.color14:      base0C
-*.color15:      base07
+*color8:       base03
+*color9:       base08
+*color10:      base0B
+*color11:      base0A
+*color12:      base0D
+*color13:      base0E
+*color14:      base0C
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/templates/xresources/light.xresources.erb
+++ b/templates/xresources/light.xresources.erb
@@ -22,33 +22,33 @@
 #define base0E #<%= @base["0E"]["hex"] %>
 #define base0F #<%= @base["0F"]["hex"] %>
 
-*.foreground:   base02
-*.background:   base07
-*.cursorColor:  base02
+*foreground:   base02
+*background:   base07
+*cursorColor:  base02
 
-*.color0:       base00
-*.color1:       base08
-*.color2:       base0B
-*.color3:       base0A
-*.color4:       base0D
-*.color5:       base0E
-*.color6:       base0C
-*.color7:       base05
+*color0:       base00
+*color1:       base08
+*color2:       base0B
+*color3:       base0A
+*color4:       base0D
+*color5:       base0E
+*color6:       base0C
+*color7:       base05
 
-*.color8:       base03
-*.color9:       base09
-*.color10:      base01
-*.color11:      base02
-*.color12:      base04
-*.color13:      base06
-*.color14:      base0F
-*.color15:      base07
+*color8:       base03
+*color9:       base09
+*color10:      base01
+*color11:      base02
+*color12:      base04
+*color13:      base06
+*color14:      base0F
+*color15:      base07
 
 ! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
 ! use 'shell' template to set these if necessary
-*.color16:      base09
-*.color17:      base0F
-*.color18:      base01
-*.color19:      base02
-*.color20:      base04
-*.color21:      base06
+*color16:      base09
+*color17:      base0F
+*color18:      base01
+*color19:      base02
+*color20:      base04
+*color21:      base06

--- a/templates/xresources/light.xresources.erb
+++ b/templates/xresources/light.xresources.erb
@@ -43,12 +43,3 @@
 *color13:      base06
 *color14:      base0F
 *color15:      base07
-
-! Note: colors beyond 15 might not be loaded (e.g., xterm, urxvt),
-! use 'shell' template to set these if necessary
-*color16:      base09
-*color17:      base0F
-*color18:      base01
-*color19:      base02
-*color20:      base04
-*color21:      base06


### PR DESCRIPTION
Here's the relevant excerpt from the *RESOURCES* section of `man X` :

    If a ResourceName contains a contiguous sequence of two or more Binding
    characters, the sequence will be replaced with single "." character if
    the sequence contains only "." characters, otherwise the sequence will
    be replaced with a single "*" character.

I also removed lines from `xresources.light.erb` that should only exist in `xresources.256.light.erb`.