### PR TITLE
Added faces for popup.el to emacs templates

### DIFF
--- a/templates/emacs/-dark-theme.el.erb
+++ b/templates/emacs/-dark-theme.el.erb
@@ -81,6 +81,16 @@
    `(isearch-lazy-highlight-face ((t (:foreground ,base0C :background ,base01 :inverse-video t))))
    `(isearch-fail ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
 
+   ;; Popups
+   `(popup-face ((t (:foreground ,base05 :background ,base02))))
+   `(popup-isearch-match-face ((t (:background ,base0C))))
+   `(popup-scroll-bar-background-face ((t (:background ,base03))))
+   `(popup-scroll-bar-foreground-face ((t (:background ,base05))))
+   `(popup-summary-face ((t (:foreground ,base04))))
+   `(popup-tip-face ((t (:foreground ,base00 :background ,base0A))))
+   `(popup-menu-mouse-face ((t (:foreground ,base00 :background ,base0D))))
+   `(popup-menu-selection-face ((t (:foreground ,base00 :background ,base0C))))
+
    ;; Flymake
    `(flymake-warnline ((t (:underline ,base09 :background ,base01))))
    `(flymake-errline ((t (:underline ,base08 :background ,base01))))

--- a/templates/emacs/-dark-theme.el.erb
+++ b/templates/emacs/-dark-theme.el.erb
@@ -83,7 +83,7 @@
 
    ;; Popups
    `(popup-face ((t (:foreground ,base05 :background ,base02))))
-   `(popup-isearch-match-face ((t (:background ,base0C))))
+   `(popup-isearch-match ((t (:foreground ,base00 :background ,base0B))))
    `(popup-scroll-bar-background-face ((t (:background ,base03))))
    `(popup-scroll-bar-foreground-face ((t (:background ,base05))))
    `(popup-summary-face ((t (:foreground ,base04))))

--- a/templates/emacs/-light-theme.el.erb
+++ b/templates/emacs/-light-theme.el.erb
@@ -82,8 +82,8 @@
    `(isearch-fail ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
 
    ;; Popups
-   `(popup-face ((t (:foreground ,base02 :background ,base05))))		
-   `(popup-isearch-match-face ((t (:background ,base0C))))
+   `(popup-face ((t (:foreground ,base02 :background ,base05))))	
+   `(popup-isearch-match ((t (:foreground ,base07 :background ,base0B))))
    `(popup-scroll-bar-background-face ((t (:background ,base04))))
    `(popup-scroll-bar-foreground-face ((t (:background ,base02))))
    `(popup-summary-face ((t (:foreground ,base03))))

--- a/templates/emacs/-light-theme.el.erb
+++ b/templates/emacs/-light-theme.el.erb
@@ -81,6 +81,16 @@
    `(isearch-lazy-highlight-face ((t (:foreground ,base0C :background ,base01 :inverse-video t))))
    `(isearch-fail ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
 
+   ;; Popups
+   `(popup-face ((t (:foreground ,base02 :background ,base05))))		
+   `(popup-isearch-match-face ((t (:background ,base0C))))
+   `(popup-scroll-bar-background-face ((t (:background ,base04))))
+   `(popup-scroll-bar-foreground-face ((t (:background ,base02))))
+   `(popup-summary-face ((t (:foreground ,base03))))
+   `(popup-tip-face ((t (:foreground ,base07 :background ,base0A))))
+   `(popup-menu-mouse-face ((t (:foreground ,base07 :background ,base0D))))
+   `(popup-menu-selection-face ((t (:foreground ,base07 :background ,base0C))))
+
    ;; Flymake
    `(flymake-warnline ((t (:underline ,base09 :background ,base01))))
    `(flymake-errline ((t (:underline ,base08 :background ,base01))))

--- a/templates/emacs/-light-theme.el.erb
+++ b/templates/emacs/-light-theme.el.erb
@@ -31,23 +31,23 @@
    'base16-<%= @slug %>-light
 
    ;; Built-in stuff (Emacs 23)
-   `(border ((t (:background ,base03))))
+   `(border ((t (:background ,base04))))
    `(border-glyph ((t (nil))))
    `(cursor ((t (:background ,base08))))
    `(default ((t (:background ,base07 :foreground ,base02))))
-   `(fringe ((t (:background ,base02))))
-   `(gui-element ((t (:background ,base03 :foreground ,base06))))
-   `(highlight ((t (:background ,base01))))
+   `(fringe ((t (:background ,base05))))
+   `(gui-element ((t (:background ,base04 :foreground ,base01))))
+   `(highlight ((t (:background ,base06))))
    `(link ((t (:foreground ,base0D))))
    `(link-visited ((t (:foreground ,base0E))))
    `(minibuffer-prompt ((t (:foreground ,base0D))))
-   `(mode-line ((t (:background ,base02 :foreground ,base04 :box nil))))
+   `(mode-line ((t (:background ,base05 :foreground ,base03 :box nil))))
    `(mode-line-buffer-id ((t (:foreground ,base0E :background nil))))
-   `(mode-line-emphasis ((t (:foreground ,base06 :slant italic))))
+   `(mode-line-emphasis ((t (:foreground ,base01 :slant italic))))
    `(mode-line-highlight ((t (:foreground ,base0E :box nil :weight bold))))
-   `(mode-line-inactive ((t (:background ,base01 :foreground ,base03 :box nil))))
-   `(region ((t (:background ,base02))))
-   `(secondary-selection ((t (:background ,base03))))
+   `(mode-line-inactive ((t (:background ,base06 :foreground ,base04 :box nil))))
+   `(region ((t (:background ,base05))))
+   `(secondary-selection ((t (:background ,base04))))
    `(error ((t (:foreground ,base08 :weight bold))))
    `(warning ((t (:foreground ,base09 :weight bold))))
    `(success ((t (:foreground ,base0B :weight bold))))
@@ -56,11 +56,11 @@
 
    ;; Font-lock stuff
    `(font-lock-builtin-face ((t (:foreground ,base0C))))
-   `(font-lock-comment-delimiter-face ((t (:foreground ,base02))))
-   `(font-lock-comment-face ((t (:foreground ,base03))))
+   `(font-lock-comment-delimiter-face ((t (:foreground ,base05))))
+   `(font-lock-comment-face ((t (:foreground ,base04))))
    `(font-lock-constant-face ((t (:foreground ,base09))))
-   `(font-lock-doc-face ((t (:foreground ,base04))))
-   `(font-lock-doc-string-face ((t (:foreground ,base03))))
+   `(font-lock-doc-face ((t (:foreground ,base03))))
+   `(font-lock-doc-string-face ((t (:foreground ,base04))))
    `(font-lock-function-name-face ((t (:foreground ,base0D))))
    `(font-lock-keyword-face ((t (:foreground ,base0E))))
    `(font-lock-negation-char-face ((t (:foreground ,base0B))))
@@ -73,16 +73,16 @@
    `(font-lock-warning-face ((t (:foreground ,base08))))
 
    ;; linum-mode
-   `(linum ((t (:background ,base01 :foreground ,base03))))
+   `(linum ((t (:background ,base06 :foreground ,base04))))
 
    ;; Search
-   `(match ((t (:foreground ,base0D :background ,base01 :inverse-video t))))
-   `(isearch ((t (:foreground ,base0A :background ,base01 :inverse-video t))))
-   `(isearch-lazy-highlight-face ((t (:foreground ,base0C :background ,base01 :inverse-video t))))
-   `(isearch-fail ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
+   `(match ((t (:foreground ,base0D :background ,base06 :inverse-video t))))
+   `(isearch ((t (:foreground ,base0A :background ,base06 :inverse-video t))))
+   `(isearch-lazy-highlight-face ((t (:foreground ,base0C :background ,base06 :inverse-video t))))
+   `(isearch-fail ((t (:background ,base06 :inherit font-lock-warning-face :inverse-video t))))
 
    ;; Popups
-   `(popup-face ((t (:foreground ,base02 :background ,base05))))	
+   `(popup-face ((t (:foreground ,base02 :background ,base05))))
    `(popup-isearch-match ((t (:foreground ,base07 :background ,base0B))))
    `(popup-scroll-bar-background-face ((t (:background ,base04))))
    `(popup-scroll-bar-foreground-face ((t (:background ,base02))))
@@ -92,8 +92,8 @@
    `(popup-menu-selection-face ((t (:foreground ,base07 :background ,base0C))))
 
    ;; Flymake
-   `(flymake-warnline ((t (:underline ,base09 :background ,base01))))
-   `(flymake-errline ((t (:underline ,base08 :background ,base01))))
+   `(flymake-warnline ((t (:underline ,base09 :background ,base06))))
+   `(flymake-errline ((t (:underline ,base08 :background ,base06))))
 
    ;; Clojure errors
    `(clojure-test-failure-face ((t (:background nil :inherit flymake-warnline))))
@@ -102,7 +102,7 @@
 
    ;; For Brian Carper's extended clojure syntax table
    `(clojure-keyword ((t (:foreground ,base0A))))
-   `(clojure-parens ((t (:foreground ,base06))))
+   `(clojure-parens ((t (:foreground ,base01))))
    `(clojure-braces ((t (:foreground ,base0B))))
    `(clojure-brackets ((t (:foreground ,base0A))))
    `(clojure-double-quote ((t (:foreground ,base0C :background nil))))
@@ -110,9 +110,9 @@
    `(clojure-java-call ((t (:foreground ,base0E))))
 
    ;; MMM-mode
-   `(mmm-code-submode-face ((t (:background ,base03))))
+   `(mmm-code-submode-face ((t (:background ,base04))))
    `(mmm-comment-submode-face ((t (:inherit font-lock-comment-face))))
-   `(mmm-output-submode-face ((t (:background ,base03))))
+   `(mmm-output-submode-face ((t (:background ,base04))))
 
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face ((t (:foreground ,base0E))))
@@ -122,34 +122,34 @@
    `(rainbow-delimiters-depth-5-face ((t (:foreground ,base0A))))
    `(rainbow-delimiters-depth-6-face ((t (:foreground ,base09))))
    `(rainbow-delimiters-depth-7-face ((t (:foreground ,base08))))
-   `(rainbow-delimiters-depth-8-face ((t (:foreground ,base03))))
-   `(rainbow-delimiters-depth-9-face ((t (:foreground ,base05))))
+   `(rainbow-delimiters-depth-8-face ((t (:foreground ,base04))))
+   `(rainbow-delimiters-depth-9-face ((t (:foreground ,base02))))
 
    ;; IDO
-   `(ido-subdir ((t (:foreground ,base04))))
+   `(ido-subdir ((t (:foreground ,base03))))
    `(ido-first-match ((t (:foreground ,base09 :weight bold))))
    `(ido-only-match ((t (:foreground ,base08 :weight bold))))
-   `(ido-indicator ((t (:foreground ,base08 :background ,base01))))
-   `(ido-virtual ((t (:foreground ,base04))))
+   `(ido-indicator ((t (:foreground ,base08 :background ,base06))))
+   `(ido-virtual ((t (:foreground ,base03))))
 
    ;; which-function
    `(which-func ((t (:foreground ,base0D :background nil :weight bold))))
 
    `(trailing-whitespace ((t (:background ,base0C :foreground ,base0A))))
    `(whitespace-empty ((t (:foreground ,base08 :background ,base0A))))
-   `(whitespace-hspace ((t (:background ,base04 :foreground ,base04))))
+   `(whitespace-hspace ((t (:background ,base03 :foreground ,base03))))
    `(whitespace-indentation ((t (:background ,base0A :foreground ,base08))))
-   `(whitespace-line ((t (:background ,base01 :foreground ,base0F))))
-   `(whitespace-newline ((t (:foreground ,base04))))
-   `(whitespace-space ((t (:background ,base01 :foreground ,base04))))
+   `(whitespace-line ((t (:background ,base06 :foreground ,base0F))))
+   `(whitespace-newline ((t (:foreground ,base03))))
+   `(whitespace-space ((t (:background ,base06 :foreground ,base03))))
    `(whitespace-space-after-tab ((t (:background ,base0A :foreground ,base08))))
    `(whitespace-space-before-tab ((t (:background ,base09 :foreground ,base08))))
-   `(whitespace-tab ((t (:background ,base04 :foreground ,base04))))
+   `(whitespace-tab ((t (:background ,base03 :foreground ,base03))))
    `(whitespace-trailing ((t (:background ,base08 :foreground ,base0A))))
 
    ;; Parenthesis matching (built-in)
-   `(show-paren-match ((t (:background ,base0D :foreground ,base03))))
-   `(show-paren-mismatch ((t (:background ,base09 :foreground ,base03))))
+   `(show-paren-match ((t (:background ,base0D :foreground ,base04))))
+   `(show-paren-mismatch ((t (:background ,base09 :foreground ,base04))))
 
    ;; Parenthesis matching (mic-paren)
    `(paren-face-match ((t (:foreground nil :background nil :inherit show-paren-match))))
@@ -157,7 +157,7 @@
    `(paren-face-no-match ((t (:foreground nil :background nil :inherit show-paren-mismatch))))
 
    ;; Parenthesis dimming (parenface)
-   `(paren-face ((t (:foreground ,base04 :background nil))))
+   `(paren-face ((t (:foreground ,base03 :background nil))))
 
    `(sh-heredoc ((t (:foreground nil :inherit font-lock-string-face :weight normal))))
    `(sh-quoted-exec ((t (:foreground nil :inherit font-lock-preprocessor-face))))
@@ -165,33 +165,33 @@
    `(slime-repl-input-face ((t (:weight normal :underline nil))))
    `(slime-repl-prompt-face ((t (:underline nil :weight bold :foreground ,base0E))))
    `(slime-repl-result-face ((t (:foreground ,base0B))))
-   `(slime-repl-output-face ((t (:foreground ,base0D :background ,base01))))
+   `(slime-repl-output-face ((t (:foreground ,base0D :background ,base06))))
 
    `(csv-separator-face ((t (:foreground ,base09))))
 
    `(diff-added ((t (:foreground ,base0B))))
    `(diff-changed ((t (:foreground ,base0A))))
    `(diff-removed ((t (:foreground ,base08))))
-   `(diff-header ((t (:background ,base01))))
-   `(diff-file-header ((t (:background ,base02))))
-   `(diff-hunk-header ((t (:background ,base01 :foreground ,base0E))))
+   `(diff-header ((t (:background ,base06))))
+   `(diff-file-header ((t (:background ,base05))))
+   `(diff-hunk-header ((t (:background ,base06 :foreground ,base0E))))
 
    `(ediff-even-diff-A ((t (:foreground nil :background nil :inverse-video t))))
    `(ediff-even-diff-B ((t (:foreground nil :background nil :inverse-video t))))
-   `(ediff-odd-diff-A  ((t (:foreground ,base04 :background nil :inverse-video t))))
-   `(ediff-odd-diff-B  ((t (:foreground ,base04 :background nil :inverse-video t))))
+   `(ediff-odd-diff-A  ((t (:foreground ,base03 :background nil :inverse-video t))))
+   `(ediff-odd-diff-B  ((t (:foreground ,base03 :background nil :inverse-video t))))
 
    `(eldoc-highlight-function-argument ((t (:foreground ,base0B :weight bold))))
 
    ;; undo-tree
-   `(undo-tree-visualizer-default-face ((t (:foreground ,base06))))
+   `(undo-tree-visualizer-default-face ((t (:foreground ,base01))))
    `(undo-tree-visualizer-current-face ((t (:foreground ,base0B :weight bold))))
    `(undo-tree-visualizer-active-branch-face ((t (:foreground ,base08))))
    `(undo-tree-visualizer-register-face ((t (:foreground ,base0A))))
 
    ;; auctex
    `(font-latex-bold-face ((t (:foreground ,base0B))))
-   `(font-latex-doctex-documentation-face ((t (:background ,base03))))
+   `(font-latex-doctex-documentation-face ((t (:background ,base04))))
    `(font-latex-italic-face ((t (:foreground ,base0B))))
    `(font-latex-math-face ((t (:foreground ,base09))))
    `(font-latex-sectioning-0-face ((t (:foreground ,base0A))))
@@ -214,7 +214,7 @@
    `(diredp-file-name ((t (:foreground ,base0A))))
    `(diredp-file-suffix ((t (:foreground ,base0B))))
    `(diredp-flag-mark-line ((t (:background nil :inherit highlight))))
-   `(diredp-ignored-file-name ((t (:foreground ,base04))))
+   `(diredp-ignored-file-name ((t (:foreground ,base03))))
    `(diredp-link-priv ((t (:background nil :foreground ,base0E))))
    `(diredp-mode-line-flagged ((t (:foreground ,base08))))
    `(diredp-mode-line-marked ((t (:foreground ,base0B))))
@@ -227,8 +227,8 @@
    `(diredp-write-priv ((t (:foreground ,base0A :background nil))))
 
    ;; term and ansi-term
-   `(term-color-black ((t (:foreground ,base02 :background ,base00))))
-   `(term-color-white ((t (:foreground ,base05 :background ,base07))))
+   `(term-color-black ((t (:foreground ,base05 :background ,base07))))
+   `(term-color-white ((t (:foreground ,base02 :background ,base00))))
    `(term-color-red ((t (:foreground ,base08 :background ,base08))))
    `(term-color-yellow ((t (:foreground ,base0A :background ,base0A))))
    `(term-color-green ((t (:foreground ,base0B :background ,base0B))))
@@ -240,7 +240,7 @@
    `(magit-branch ((t (:foreground ,base0B))))
    `(magit-header ((t (:inherit nil :weight bold))))
    `(magit-item-highlight ((t (:inherit highlight :background nil))))
-   `(magit-log-graph ((t (:foreground ,base04))))
+   `(magit-log-graph ((t (:foreground ,base03))))
    `(magit-log-sha1 ((t (:foreground ,base0E))))
    `(magit-log-head-label-bisect-bad ((t (:foreground ,base08))))
    `(magit-log-head-label-bisect-good ((t (:foreground ,base0B))))
@@ -252,7 +252,7 @@
 
    `(link ((t (:foreground nil :underline t))))
    `(widget-button ((t (:underline t))))
-   `(widget-field ((t (:background ,base03 :box (:line-width 1 :color ,base06)))))
+   `(widget-field ((t (:background ,base04 :box (:line-width 1 :color ,base01)))))
 
    ;; Compilation (most faces politely inherit from 'success, 'error, 'warning etc.)
    `(compilation-column-number ((t (:foreground ,base0A))))
@@ -263,7 +263,7 @@
    `(compilation-mode-line-run ((t (:foreground ,base0D))))
 
    ;; Grep
-   `(grep-context-face ((t (:foreground ,base04))))
+   `(grep-context-face ((t (:foreground ,base03))))
    `(grep-error-face ((t (:foreground ,base08 :weight bold :underline t))))
    `(grep-hit-face ((t (:foreground ,base0D))))
    `(grep-match-face ((t (:foreground nil :background nil :inherit match))))
@@ -278,20 +278,20 @@
    `(org-agenda-structure ((t (:foreground ,base0E))))
    `(org-agenda-date ((t (:foreground ,base0D :underline nil))))
    `(org-agenda-done ((t (:foreground ,base0B))))
-   `(org-agenda-dimmed-todo-face ((t (:foreground ,base04))))
+   `(org-agenda-dimmed-todo-face ((t (:foreground ,base03))))
    `(org-block ((t (:foreground ,base09))))
    `(org-code ((t (:foreground ,base0A))))
-   `(org-column ((t (:background ,base03))))
+   `(org-column ((t (:background ,base04))))
    `(org-column-title ((t (:inherit org-column :weight bold :underline t))))
    `(org-date ((t (:foreground ,base0E :underline t))))
    `(org-document-info ((t (:foreground ,base0C))))
    `(org-document-info-keyword ((t (:foreground ,base0B))))
    `(org-document-title ((t (:weight bold :foreground ,base09 :height 1.44))))
    `(org-done ((t (:foreground ,base0B))))
-   `(org-ellipsis ((t (:foreground ,base04))))
+   `(org-ellipsis ((t (:foreground ,base03))))
    `(org-footnote ((t (:foreground ,base0C))))
    `(org-formula ((t (:foreground ,base08))))
-   `(org-hide ((t (:foreground ,base03))))
+   `(org-hide ((t (:foreground ,base04))))
    `(org-link ((t (:foreground ,base0D))))
    `(org-scheduled ((t (:foreground ,base0B))))
    `(org-scheduled-previously ((t (:foreground ,base09))))
@@ -305,8 +305,8 @@
    `(markdown-url-face ((t (:inherit link))))
    `(markdown-link-face ((t (:foreground ,base0D :underline t))))
 
-   `(hl-sexp-face ((t (:background ,base03))))
-   `(highlight-80+ ((t (:background ,base03))))
+   `(hl-sexp-face ((t (:background ,base04))))
+   `(highlight-80+ ((t (:background ,base04))))
 
    ;; Python-specific overrides
    `(py-builtins-face ((t (:foreground ,base09 :weight normal))))
@@ -341,13 +341,13 @@
    `(rng-error-face ((t (:underline ,base08))))
 
    ;; RHTML
-   `(erb-delim-face ((t (:background ,base03))))
-   `(erb-exec-face ((t (:background ,base03 :weight bold))))
-   `(erb-exec-delim-face ((t (:background ,base03))))
-   `(erb-out-face ((t (:background ,base03 :weight bold))))
-   `(erb-out-delim-face ((t (:background ,base03))))
-   `(erb-comment-face ((t (:background ,base03 :weight bold :slant italic))))
-   `(erb-comment-delim-face ((t (:background ,base03))))
+   `(erb-delim-face ((t (:background ,base04))))
+   `(erb-exec-face ((t (:background ,base04 :weight bold))))
+   `(erb-exec-delim-face ((t (:background ,base04))))
+   `(erb-out-face ((t (:background ,base04 :weight bold))))
+   `(erb-out-delim-face ((t (:background ,base04))))
+   `(erb-comment-face ((t (:background ,base04 :weight bold :slant italic))))
+   `(erb-comment-delim-face ((t (:background ,base04))))
 
    ;; Message-mode
    `(message-header-other ((t (:foreground nil :background nil :weight normal))))
@@ -367,14 +367,14 @@
    `(jabber-chat-text-error ((t (:foreground ,base08))))
 
    `(jabber-roster-user-online ((t (:foreground ,base0B))))
-   `(jabber-roster-user-xa ((t :foreground ,base04)))
+   `(jabber-roster-user-xa ((t :foreground ,base03)))
    `(jabber-roster-user-dnd ((t :foreground ,base0A)))
    `(jabber-roster-user-away ((t (:foreground ,base09))))
    `(jabber-roster-user-chatty ((t (:foreground ,base0E))))
    `(jabber-roster-user-error ((t (:foreground ,base08))))
-   `(jabber-roster-user-offline ((t (:foreground ,base04))))
+   `(jabber-roster-user-offline ((t (:foreground ,base03))))
 
-   `(jabber-rare-time-face ((t (:foreground ,base04))))
+   `(jabber-rare-time-face ((t (:foreground ,base03))))
    `(jabber-activity-face ((t (:foreground ,base0E))))
    `(jabber-activity-personal-face ((t (:foreground ,base0C))))
 
@@ -396,55 +396,55 @@
    `(gnus-signature ((t (:inherit font-lock-comment-face))))
 
    `(gnus-summary-normal-unread ((t (:foreground ,base0D :weight normal))))
-   `(gnus-summary-normal-read ((t (:foreground ,base06 :weight normal))))
+   `(gnus-summary-normal-read ((t (:foreground ,base01 :weight normal))))
    `(gnus-summary-normal-ancient ((t (:foreground ,base0C :weight normal))))
    `(gnus-summary-normal-ticked ((t (:foreground ,base09 :weight normal))))
-   `(gnus-summary-low-unread ((t (:foreground ,base04 :weight normal))))
-   `(gnus-summary-low-read ((t (:foreground ,base04 :weight normal))))
-   `(gnus-summary-low-ancient ((t (:foreground ,base04 :weight normal))))
+   `(gnus-summary-low-unread ((t (:foreground ,base03 :weight normal))))
+   `(gnus-summary-low-read ((t (:foreground ,base03 :weight normal))))
+   `(gnus-summary-low-ancient ((t (:foreground ,base03 :weight normal))))
    `(gnus-summary-high-unread ((t (:foreground ,base0A :weight normal))))
    `(gnus-summary-high-read ((t (:foreground ,base0B :weight normal))))
    `(gnus-summary-high-ancient ((t (:foreground ,base0B :weight normal))))
    `(gnus-summary-high-ticked ((t (:foreground ,base09 :weight normal))))
    `(gnus-summary-cancelled ((t (:foreground ,base08 :background nil :weight normal))))
 
-   `(gnus-group-mail-low ((t (:foreground ,base04))))
-   `(gnus-group-mail-low-empty ((t (:foreground ,base04))))
+   `(gnus-group-mail-low ((t (:foreground ,base03))))
+   `(gnus-group-mail-low-empty ((t (:foreground ,base03))))
    `(gnus-group-mail-1 ((t (:foreground nil :weight normal :inherit outline-1))))
    `(gnus-group-mail-2 ((t (:foreground nil :weight normal :inherit outline-2))))
    `(gnus-group-mail-3 ((t (:foreground nil :weight normal :inherit outline-3))))
    `(gnus-group-mail-4 ((t (:foreground nil :weight normal :inherit outline-4))))
    `(gnus-group-mail-5 ((t (:foreground nil :weight normal :inherit outline-5))))
    `(gnus-group-mail-6 ((t (:foreground nil :weight normal :inherit outline-6))))
-   `(gnus-group-mail-1-empty ((t (:inherit gnus-group-mail-1 :foreground ,base04))))
-   `(gnus-group-mail-2-empty ((t (:inherit gnus-group-mail-2 :foreground ,base04))))
-   `(gnus-group-mail-3-empty ((t (:inherit gnus-group-mail-3 :foreground ,base04))))
-   `(gnus-group-mail-4-empty ((t (:inherit gnus-group-mail-4 :foreground ,base04))))
-   `(gnus-group-mail-5-empty ((t (:inherit gnus-group-mail-5 :foreground ,base04))))
-   `(gnus-group-mail-6-empty ((t (:inherit gnus-group-mail-6 :foreground ,base04))))
+   `(gnus-group-mail-1-empty ((t (:inherit gnus-group-mail-1 :foreground ,base03))))
+   `(gnus-group-mail-2-empty ((t (:inherit gnus-group-mail-2 :foreground ,base03))))
+   `(gnus-group-mail-3-empty ((t (:inherit gnus-group-mail-3 :foreground ,base03))))
+   `(gnus-group-mail-4-empty ((t (:inherit gnus-group-mail-4 :foreground ,base03))))
+   `(gnus-group-mail-5-empty ((t (:inherit gnus-group-mail-5 :foreground ,base03))))
+   `(gnus-group-mail-6-empty ((t (:inherit gnus-group-mail-6 :foreground ,base03))))
    `(gnus-group-news-1 ((t (:foreground nil :weight normal :inherit outline-5))))
    `(gnus-group-news-2 ((t (:foreground nil :weight normal :inherit outline-6))))
    `(gnus-group-news-3 ((t (:foreground nil :weight normal :inherit outline-7))))
    `(gnus-group-news-4 ((t (:foreground nil :weight normal :inherit outline-8))))
    `(gnus-group-news-5 ((t (:foreground nil :weight normal :inherit outline-1))))
    `(gnus-group-news-6 ((t (:foreground nil :weight normal :inherit outline-2))))
-   `(gnus-group-news-1-empty ((t (:inherit gnus-group-news-1 :foreground ,base04))))
-   `(gnus-group-news-2-empty ((t (:inherit gnus-group-news-2 :foreground ,base04))))
-   `(gnus-group-news-3-empty ((t (:inherit gnus-group-news-3 :foreground ,base04))))
-   `(gnus-group-news-4-empty ((t (:inherit gnus-group-news-4 :foreground ,base04))))
-   `(gnus-group-news-5-empty ((t (:inherit gnus-group-news-5 :foreground ,base04))))
-   `(gnus-group-news-6-empty ((t (:inherit gnus-group-news-6 :foreground ,base04))))
+   `(gnus-group-news-1-empty ((t (:inherit gnus-group-news-1 :foreground ,base03))))
+   `(gnus-group-news-2-empty ((t (:inherit gnus-group-news-2 :foreground ,base03))))
+   `(gnus-group-news-3-empty ((t (:inherit gnus-group-news-3 :foreground ,base03))))
+   `(gnus-group-news-4-empty ((t (:inherit gnus-group-news-4 :foreground ,base03))))
+   `(gnus-group-news-5-empty ((t (:inherit gnus-group-news-5 :foreground ,base03))))
+   `(gnus-group-news-6-empty ((t (:inherit gnus-group-news-6 :foreground ,base03))))
 
    `(erc-direct-msg-face ((t (:foreground ,base09))))
    `(erc-error-face ((t (:foreground ,base08))))
-   `(erc-header-face ((t (:foreground ,base06 :background ,base04))))
+   `(erc-header-face ((t (:foreground ,base01 :background ,base03))))
    `(erc-input-face ((t (:foreground ,base0B))))
    `(erc-keyword-face ((t (:foreground ,base0A))))
    `(erc-current-nick-face ((t (:foreground ,base0B))))
    `(erc-my-nick-face ((t (:foreground ,base0B))))
    `(erc-nick-default-face ((t (:weight normal :foreground ,base0E))))
    `(erc-nick-msg-face ((t (:weight normal :foreground ,base0A))))
-   `(erc-notice-face ((t (:foreground ,base04))))
+   `(erc-notice-face ((t (:foreground ,base03))))
    `(erc-pal-face ((t (:foreground ,base09))))
    `(erc-prompt-face ((t (:foreground ,base0D))))
    `(erc-timestamp-face ((t (:foreground ,base0C))))
@@ -457,12 +457,12 @@
   (custom-theme-set-variables
    'base16-<%= @slug %>-light
 
-   `(ansi-color-names-vector
+  `(ansi-color-names-vector
      ;; black, base08, base0B, base0A, base0D, magenta, cyan, white
-     [,base00 ,base08 ,base0B ,base0A ,base0D ,base0E ,base0D ,base05])
+     [,base07 ,base08 ,base0B ,base0A ,base0D ,base0E ,base0D ,base02])
    `(ansi-term-color-vector
      ;; black, base08, base0B, base0A, base0D, magenta, cyan, white
-     [unspecified ,base00 ,base08 ,base0B ,base0A ,base0D ,base0E ,base0D ,base05])))
+     [unspecified ,base07 ,base08 ,base0B ,base0A ,base0D ,base0E ,base0D ,base02])))
 
 (provide-theme 'base16-<%= @slug %>-light)
 


### PR DESCRIPTION
I edited the emacs templates to theme the faces provided by popup.el (which is what auto-complete uses to provide its popups).

I tried to make sane color choices. If there are guidelines somewhere ala solarized as to which of the steps between `base00` and `base07` should be comments / selections / etc, I'm interested in hearing.