### PR TITLE
Add template for TeX

### DIFF
--- a/templates/tex-xcolor/tex.erb
+++ b/templates/tex-xcolor/tex.erb
@@ -1,0 +1,16 @@
+\definecolor{base00}{HTML}{<%= @base["00"]["hex"].upcase %>}
+\definecolor{base01}{HTML}{<%= @base["01"]["hex"].upcase %>}
+\definecolor{base02}{HTML}{<%= @base["02"]["hex"].upcase %>}
+\definecolor{base03}{HTML}{<%= @base["03"]["hex"].upcase %>}
+\definecolor{base04}{HTML}{<%= @base["04"]["hex"].upcase %>}
+\definecolor{base05}{HTML}{<%= @base["05"]["hex"].upcase %>}
+\definecolor{base06}{HTML}{<%= @base["06"]["hex"].upcase %>}
+\definecolor{base07}{HTML}{<%= @base["07"]["hex"].upcase %>}
+\definecolor{base08}{HTML}{<%= @base["08"]["hex"].upcase %>}
+\definecolor{base09}{HTML}{<%= @base["09"]["hex"].upcase %>}
+\definecolor{base0A}{HTML}{<%= @base["0A"]["hex"].upcase %>}
+\definecolor{base0B}{HTML}{<%= @base["0B"]["hex"].upcase %>}
+\definecolor{base0C}{HTML}{<%= @base["0C"]["hex"].upcase %>}
+\definecolor{base0D}{HTML}{<%= @base["0D"]["hex"].upcase %>}
+\definecolor{base0E}{HTML}{<%= @base["0E"]["hex"].upcase %>}
+\definecolor{base0F}{HTML}{<%= @base["0F"]["hex"].upcase %>}


### PR DESCRIPTION
This defines the Base16 colors for TeX. In order to use these you need to
use the `xcolor` package, fe.:

```tex
  \documentclass{article}
  \usepackage{xcolor}
  \input{base16-default}
  \begin{document}
    \textcolor{base08}{foobar}
  \end{document}
```