### PR TITLE
Check if uuidgen is installed

### DIFF
--- a/templates/gnome-terminal/dark.sh.erb
+++ b/templates/gnome-terminal/dark.sh.erb
@@ -78,7 +78,7 @@ if which "$DCONF" > /dev/null 2>&1; then
         unset PROFILE_SLUG
         unset DCONF
         unset UUIDGEN
-        exit 0
+        return 0
     fi
 fi
 

--- a/templates/gnome-terminal/dark.sh.erb
+++ b/templates/gnome-terminal/dark.sh.erb
@@ -39,6 +39,9 @@ dlist_append() {
 
 # Newest versions of gnome-terminal use dconf
 if which "$DCONF" > /dev/null 2>&1; then
+    #check that uuidgen is available
+    type $UUIDGEN >/dev/null 2>&1 || { echo >&2 "Requires uuidgen but it's not installed.  Aborting!"; return 1; }
+
     [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
 
     if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then

--- a/templates/gnome-terminal/light.sh.erb
+++ b/templates/gnome-terminal/light.sh.erb
@@ -79,7 +79,7 @@ if which "$DCONF" > /dev/null 2>&1; then
         unset PROFILE_SLUG
         unset DCONF
         unset UUIDGEN
-        exit 0
+        return 0
     fi
 fi
 

--- a/templates/gnome-terminal/light.sh.erb
+++ b/templates/gnome-terminal/light.sh.erb
@@ -39,6 +39,9 @@ dlist_append() {
 
 # Newest versions of gnome-terminal use dconf
 if which "$DCONF" > /dev/null 2>&1; then
+    #check that uuidgen is available
+    type $UUIDGEN >/dev/null 2>&1 || { echo >&2 "Requires uuidgen but it's not installed.  Aborting!"; return 1; }
+
     [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
 
     if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then


### PR DESCRIPTION
While trying to install base16 schemes for gnome terminal, I ran into troubles. The created shell scripts made my other terminal profiles unusable, because I missed `uuidgen`. Took me a while to figure this out and get back to normal state.

The commit includes a checks for `uuidgen`. If it is not found, it just aborts the execution.

I also replaced the two exit commands with return - as you are supposed to source the script (`. <script>`), the exit command always closed the terminal. `return` just stops the execution of the file.