### PR TITLE
small edits for prettify.js

### DIFF
--- a/templates/prettify.js/dark.css.erb
+++ b/templates/prettify.js/dark.css.erb
@@ -129,11 +129,13 @@
 /* Style */
 pre.prettyprint {
   background: #<%= @base["00"]["hex"] %>;
-  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+  color: #<%= @base["02"]["hex"] %>;
+  font-family: Consolas, Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", Monaco, monospace;
   font-size: 12px;
   line-height: 1.5;
-  border: 1px solid #<%= @base["07"]["hex"] %>;
+  border: 1px solid #<%= @base["00"]["hex"] %>;
   padding: 10px;
+  border-radius: 3px;
 }
 
 /* Specify class=linenums on a pre to get line numbering */

--- a/templates/prettify.js/light.css.erb
+++ b/templates/prettify.js/light.css.erb
@@ -128,12 +128,14 @@
 }
 /* Style */
 pre.prettyprint {
-  background: <%= @base["07"]["hex"] %>;
-  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+  background: #<%= @base["07"]["hex"] %>;
+  color: #<%= @base["05"]["hex"] %>;
+  font-family: Consolas, Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", Monaco, monospace;
   font-size: 12px;
   line-height: 1.5;
-  border: 1px solid #<%= @base["00"]["hex"] %>;
+  border: 1px solid #<%= @base["06"]["hex"] %>;
   padding: 10px;
+  border-radius: 3px;
 }
 
 /* Specify class=linenums on a pre to get line numbering */


### PR DESCRIPTION
Small edits, most important one is in the light scheme:  an omitted `#` for background-color of `pre` code-block: fixed here. 
Also some minor esthetic changes:
- didn't think the dark border on the light scheme was doing light-schemes any favours: changed this to base06
- Consolas is one of the best monospaced fonts around, so gave that one priority in the font-stack.
- some small border-radius on the `pre`