### PR TITLE
Templates: Atom: moved hard-coded colors out of `base`

### DIFF
--- a/templates/atom/-dark-base.less.erb
+++ b/templates/atom/-dark-base.less.erb
@@ -2,6 +2,7 @@
 // Base16 scheme and Base16 Builder by Chris Kempson (https://github.com/chriskempson)
 
 @import "base16-<%= @slug %>-dark-syntax-variables.less";
+
 atom-text-editor, // <- remove when Shadow DOM can't be disabled
 :host {
   color: @syntax-text-color;
@@ -50,175 +51,175 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
   }
 
   .line-number.cursor-line-no-selection, .line.cursor-line {
-    background-color: rgba(80, 80, 80, 0.33);
+    background-color: @syntax-gutter-background-color-selected;
   }
 
 }
 
 .variable.parameter.function {
-  color: #<%= @base["05"]["hex"] %>;
+  color: @base05-color;
 }
 
 .comment, .punctuation.definition.comment {
-  color: #<%= @base["03"]["hex"] %>;
+  color: @base03-color;
 }
 
 .punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.string, .punctuation.definition.parameters, .punctuation.definition.string, .punctuation.definition.array {
-  color: #<%= @base["05"]["hex"] %>;
+  color: @base05-color;
 }
 
 .none {
-  color: #<%= @base["05"]["hex"] %>;
+  color: @base05-color;
 }
 
 .keyword.operator {
-  color: #<%= @base["05"]["hex"] %>;
+  color: @base05-color;
 }
 
 .keyword {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .variable {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .entity.name.function, .meta.require, .support.function.any-method {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .support.class, .entity.name.class, .entity.name.type.class {
-  color: #<%= @base["0A"]["hex"] %>;
+  color: @base0A-color;
 }
 
 .meta.class {
-  color: #<%= @base["07"]["hex"] %>;
+  color: @base07-color;
 }
 
 .keyword.other.special-method {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .storage {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .support.function {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .string, .constant.other.symbol, .entity.other.inherited-class {
-  color: #<%= @base["0B"]["hex"] %>;
+  color: @base0B-color;
 }
 
 .constant.numeric {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .none {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .none {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .constant {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .entity.name.tag {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .entity.other.attribute-name {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .entity.other.attribute-name.id, .punctuation.definition.entity {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .meta.selector {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .none {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.heading .punctuation.definition.heading, .entity.name.section {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .keyword.other.unit {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.bold, .punctuation.definition.bold {
   font-weight: bold;
-  color: #<%= @base["0A"]["hex"] %>;
+  color: @base0A-color;
 }
 
 .markup.italic, .punctuation.definition.italic {
   font-style: italic;
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .markup.raw.inline {
-  color: #<%= @base["0B"]["hex"] %>;
+  color: @base0B-color;
 }
 
 .string.other.link {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .meta.link {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.list {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .markup.quote {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .meta.separator {
-  color: #<%= @base["05"]["hex"] %>;
-  background-color: #<%= @base["02"]["hex"] %>;
+  color: @base05-color;
+  background-color: @base02-color;
 }
 
 .markup.inserted {
-  color: #<%= @base["0B"]["hex"] %>;
+  color: @base0B-color;
 }
 
 .markup.deleted {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .markup.changed {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .constant.other.color {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .string.regexp {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .constant.character.escape {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .punctuation.section.embedded, .variable.interpolation {
-  color: #<%= @base["0F"]["hex"] %>;
+  color: @base0F-color;
 }
 
 .invalid.illegal {
-  color: #<%= @base["00"]["hex"] %>;
-  background-color: #<%= @base["08"]["hex"] %>;
+  color: @base00-color;
+  background-color: @base08-color;
 }

--- a/templates/atom/-dark-syntax-variables.less.erb
+++ b/templates/atom/-dark-syntax-variables.less.erb
@@ -4,30 +4,46 @@
 // This defines all syntax variables that syntax themes must implement when they
 // include a syntax-variables.less file.
 
+@base00-color: #<%= @base["00"]["hex"] %>;
+@base01-color: #<%= @base["01"]["hex"] %>;
+@base02-color: #<%= @base["02"]["hex"] %>;
+@base03-color: #<%= @base["03"]["hex"] %>;
+@base04-color: #<%= @base["04"]["hex"] %>;
+@base05-color: #<%= @base["05"]["hex"] %>;
+@base06-color: #<%= @base["06"]["hex"] %>;
+@base07-color: #<%= @base["07"]["hex"] %>;
+@base08-color: #<%= @base["08"]["hex"] %>;
+@base0A-color: #<%= @base["0A"]["hex"] %>;
+@base0B-color: #<%= @base["0B"]["hex"] %>;
+@base0C-color: #<%= @base["0C"]["hex"] %>;
+@base0D-color: #<%= @base["0D"]["hex"] %>;
+@base0E-color: #<%= @base["0E"]["hex"] %>;
+@base0F-color: #<%= @base["0F"]["hex"] %>;
+
 // General colors
-@syntax-text-color: #<%= @base["05"]["hex"] %>;
-@syntax-cursor-color: #<%= @base["05"]["hex"] %>;
-@syntax-selection-color: #<%= @base["02"]["hex"] %>;
-@syntax-background-color: #<%= @base["00"]["hex"] %>;
+@syntax-text-color: @base05-color;
+@syntax-cursor-color: @base05-color;
+@syntax-selection-color: @base02-color;
+@syntax-background-color: @base00-color;
 
 // Guide colors
-@syntax-wrap-guide-color: #<%= @base["03"]["hex"] %>;
-@syntax-indent-guide-color: #<%= @base["03"]["hex"] %>;
-@syntax-invisible-character-color: #<%= @base["03"]["hex"] %>;
+@syntax-wrap-guide-color: @base03-color;
+@syntax-indent-guide-color: @base03-color;
+@syntax-invisible-character-color: @base03-color;
 
 // For find and replace markers
-@syntax-result-marker-color: #<%= @base["03"]["hex"] %>;
-@syntax-result-marker-color-selected: #<%= @base["05"]["hex"] %>;
+@syntax-result-marker-color: @base03-color;
+@syntax-result-marker-color-selected: @base05-color;
 
 // Gutter colors
-@syntax-gutter-text-color: #<%= @base["05"]["hex"] %>;
-@syntax-gutter-text-color-selected: #<%= @base["05"]["hex"] %>;
-@syntax-gutter-background-color: #<%= @base["00"]["hex"] %>;
-@syntax-gutter-background-color-selected: rgba(80, 80, 80, 0.33);
+@syntax-gutter-text-color: @base05-color;
+@syntax-gutter-text-color-selected: @base05-color;
+@syntax-gutter-background-color: @base00-color;
+@syntax-gutter-background-color-selected: fadeout(@base00-color, .33);
 
 // For git diff info. i.e. in the gutter
 // These are static and were not extracted from your textmate theme
-@syntax-color-renamed: #<%= @base["0D"]["hex"] %>;
-@syntax-color-added: #<%= @base["0B"]["hex"] %>;
-@syntax-color-modified: #<%= @base["0A"]["hex"] %>;
-@syntax-color-removed: #<%= @base["08"]["hex"] %>;
+@syntax-color-renamed: @base0D-color;
+@syntax-color-added: @base0B-color;
+@syntax-color-modified: @base0A-color;
+@syntax-color-removed: @base08-color;

--- a/templates/atom/-light-base.less.erb
+++ b/templates/atom/-light-base.less.erb
@@ -51,175 +51,175 @@ atom-text-editor, // <- remove when Shadow DOM can't be disabled
   }
 
   .line-number.cursor-line-no-selection, .line.cursor-line {
-    background-color: rgba(176, 176, 176, 0.33);
+    background-color: @syntax-gutter-background-color-selected;
   }
 
 }
 
 .variable.parameter.function {
-  color: #<%= @base["02"]["hex"] %>;
+  color: @base02-color;
 }
 
 .comment, .punctuation.definition.comment {
-  color: #<%= @base["04"]["hex"] %>;
+  color: @base04-color;
 }
 
 .punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.string, .punctuation.definition.parameters, .punctuation.definition.string, .punctuation.definition.array {
-  color: #<%= @base["02"]["hex"] %>;
+  color: @base02-color;
 }
 
 .none {
-  color: #<%= @base["02"]["hex"] %>;
+  color: @base02-color;
 }
 
 .keyword.operator {
-  color: #<%= @base["02"]["hex"] %>;
+  color: @base02-color;
 }
 
 .keyword {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .variable {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .entity.name.function, .meta.require, .support.function.any-method {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .support.class, .entity.name.class, .entity.name.type.class {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .meta.class {
-  color: #<%= @base["01"]["hex"] %>;
+  color: @base01-color;
 }
 
 .keyword.other.special-method {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .storage {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .support.function {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .string, .constant.other.symbol, .entity.other.inherited-class {
-  color: #<%= @base["0B"]["hex"] %>;
+  color: @base0B-color;
 }
 
 .constant.numeric {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .none {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .none {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .constant {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .entity.name.tag {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .entity.other.attribute-name {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .entity.other.attribute-name.id, .punctuation.definition.entity {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .meta.selector {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .none {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.heading .punctuation.definition.heading, .entity.name.section {
-  color: #<%= @base["0D"]["hex"] %>;
+  color: @base0D-color;
 }
 
 .keyword.other.unit {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.bold, .punctuation.definition.bold {
   font-weight: bold;
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.italic, .punctuation.definition.italic {
   font-style: italic;
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .markup.raw.inline {
-  color: #<%= @base["0B"]["hex"] %>;
+  color: @base0B-color;
 }
 
 .string.other.link {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .meta.link {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .markup.list {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .markup.quote {
-  color: #<%= @base["09"]["hex"] %>;
+  color: @base09-color;
 }
 
 .meta.separator {
-  color: #<%= @base["02"]["hex"] %>;
-  background-color: #<%= @base["06"]["hex"] %>;
+  color: @base02-color;
+  background-color: @base06-color;
 }
 
 .markup.inserted {
-  color: #<%= @base["0B"]["hex"] %>;
+  color: @base0B-color;
 }
 
 .markup.deleted {
-  color: #<%= @base["08"]["hex"] %>;
+  color: @base08-color;
 }
 
 .markup.changed {
-  color: #<%= @base["0E"]["hex"] %>;
+  color: @base0E-color;
 }
 
 .constant.other.color {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .string.regexp {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .constant.character.escape {
-  color: #<%= @base["0C"]["hex"] %>;
+  color: @base0C-color;
 }
 
 .punctuation.section.embedded, .variable.interpolation {
-  color: #<%= @base["0F"]["hex"] %>;
+  color: @base0F-color;
 }
 
 .invalid.illegal {
-  color: #<%= @base["07"]["hex"] %>;
-  background-color: #<%= @base["08"]["hex"] %>;
+  color: @base07-color;
+  background-color: @base08-color;
 }

--- a/templates/atom/-light-syntax-variables.less.erb
+++ b/templates/atom/-light-syntax-variables.less.erb
@@ -1,30 +1,49 @@
+// Atom template by Jan T. Sott (https://github.com/idleberg/)
+// Base16 scheme and Base16 Builder by Chris Kempson (https://github.com/chriskempson)
+
 // This defines all syntax variables that syntax themes must implement when they
 // include a syntax-variables.less file.
 
+@base00-color: #<%= @base["00"]["hex"] %>;
+@base01-color: #<%= @base["01"]["hex"] %>;
+@base02-color: #<%= @base["02"]["hex"] %>;
+@base03-color: #<%= @base["03"]["hex"] %>;
+@base04-color: #<%= @base["04"]["hex"] %>;
+@base05-color: #<%= @base["05"]["hex"] %>;
+@base06-color: #<%= @base["06"]["hex"] %>;
+@base07-color: #<%= @base["07"]["hex"] %>;
+@base08-color: #<%= @base["08"]["hex"] %>;
+@base0A-color: #<%= @base["0A"]["hex"] %>;
+@base0B-color: #<%= @base["0B"]["hex"] %>;
+@base0C-color: #<%= @base["0C"]["hex"] %>;
+@base0D-color: #<%= @base["0D"]["hex"] %>;
+@base0E-color: #<%= @base["0E"]["hex"] %>;
+@base0F-color: #<%= @base["0F"]["hex"] %>;
+
 // General colors
-@syntax-text-color: #<%= @base["02"]["hex"] %>;
-@syntax-cursor-color: #<%= @base["02"]["hex"] %>;
-@syntax-selection-color: #<%= @base["06"]["hex"] %>;
-@syntax-background-color: #<%= @base["07"]["hex"] %>;
+@syntax-text-color: @base02-color;
+@syntax-cursor-color: @base02-color;
+@syntax-selection-color: @base06-color;
+@syntax-background-color: @base07-color;
 
 // Guide colors
-@syntax-wrap-guide-color: #<%= @base["06"]["hex"] %>;
-@syntax-indent-guide-color: #<%= @base["06"]["hex"] %>;
-@syntax-invisible-character-color: #<%= @base["06"]["hex"] %>;
+@syntax-wrap-guide-color: @base06-color;
+@syntax-indent-guide-color: @base06-color;
+@syntax-invisible-character-color: @base06-color;
 
 // For find and replace markers
-@syntax-result-marker-color: #<%= @base["06"]["hex"] %>;
-@syntax-result-marker-color-selected: #<%= @base["02"]["hex"] %>;
+@syntax-result-marker-color: @base06-color;
+@syntax-result-marker-color-selected: @base02-color;
 
 // Gutter colors
-@syntax-gutter-text-color: #<%= @base["02"]["hex"] %>;
-@syntax-gutter-text-color-selected: #<%= @base["02"]["hex"] %>;
-@syntax-gutter-background-color: #<%= @base["07"]["hex"] %>;
-@syntax-gutter-background-color-selected: rgba(176, 176, 176, 0.33);
+@syntax-gutter-text-color: @base02-color;
+@syntax-gutter-text-color-selected: @base02-color;
+@syntax-gutter-background-color: @base07-color;
+@syntax-gutter-background-color-selected: fadeout(@base07-color, .33);
 
 // For git diff info. i.e. in the gutter
 // These are static and were not extracted from your textmate theme
-@syntax-color-renamed: #<%= @base["0D"]["hex"] %>;
-@syntax-color-added: #<%= @base["0B"]["hex"] %>;
-@syntax-color-modified: #<%= @base["0A"]["hex"] %>;
-@syntax-color-removed: #<%= @base["08"]["hex"] %>;
+@syntax-color-renamed: @base0D-color;
+@syntax-color-added: @base0B-color;
+@syntax-color-modified: @base0A-color;
+@syntax-color-removed: @base08-color;


### PR DESCRIPTION
Taking more advantage of LESS, and keeping hard-coded colors in the `syntax-variables` file to avoid duplication. This allows for easier tweaks of a theme's 16 base colors post-build, since re-building isn't always an option once additional theme functionality has been added / modified.
