### PR TITLE
Add multiple quick templates for i3-wm

### DIFF
--- a/templates/dmenu/dark.erb
+++ b/templates/dmenu/dark.erb
@@ -1,0 +1,6 @@
+# dmenu template
+# Base16 <%= @scheme %> Dark, by <%= @author %>
+# template by Matt Parnell, @parnmatt
+
+# add this as an alias, or however you wish to run dmenu
+dmenu -nb '<%= base["00"]["hex"] %>' -nf '<%= base["03"]["hex"] %>' -sb '<%= base["0D"]["hex"] %>' -sf '<%= base["00"]["hex"] %>'

--- a/templates/dmenu/light.erb
+++ b/templates/dmenu/light.erb
@@ -1,0 +1,6 @@
+# dmenu template
+# Base16 <%= @scheme %> Light, by <%= @author %>
+# template by Matt Parnell, @parnmatt
+
+# add this as an alias, or however you wish to run dmenu
+dmenu -nb '<%= base["05"]["hex"] %>' -nf '<%= base["02"]["hex"] %>' -sb '<%= base["0D"]["hex"] %>' -sf '<%= base["01"]["hex"] %>'

--- a/templates/i3-style/i3-style.erb
+++ b/templates/i3-style/i3-style.erb
@@ -1,0 +1,66 @@
+# vim: filetype=yaml
+# i3-style Template
+# Base16 <%= @scheme %>, by <%= @author %>
+# template by Matt Parnell, @parnmatt
+---
+colors:
+    base00:              '#<%= @base["00"]["hex"] %>'
+    base01:              '#<%= @base["01"]["hex"] %>'
+    base02:              '#<%= @base["02"]["hex"] %>'
+    base03:              '#<%= @base["03"]["hex"] %>'
+    base04:              '#<%= @base["04"]["hex"] %>'
+    base05:              '#<%= @base["05"]["hex"] %>'
+    base06:              '#<%= @base["06"]["hex"] %>'
+    base07:              '#<%= @base["07"]["hex"] %>'
+    base08:              '#<%= @base["08"]["hex"] %>'
+    base09:              '#<%= @base["09"]["hex"] %>'
+    base0A:              '#<%= @base["0A"]["hex"] %>'
+    base0B:              '#<%= @base["0B"]["hex"] %>'
+    base0C:              '#<%= @base["0C"]["hex"] %>'
+    base0D:              '#<%= @base["0D"]["hex"] %>'
+    base0E:              '#<%= @base["0E"]["hex"] %>'
+    base0F:              '#<%= @base["0F"]["hex"] %>'
+
+meta:
+    description:         'Base16 <%= @scheme %>, by <%= @author %>'
+window_colors:
+    focused:
+        border:          'base0D'
+        background:      'base0D'
+        text:            'base00'
+        indicator:       'base01'
+    focused_inactive:
+        border:          'base02'
+        background:      'base02'
+        text:            'base03'
+        indicator:       'base01'
+    unfocused:
+        border:          'base01'
+        background:      'base01'
+        text:            'base03'
+        indicator:       'base01'
+    urgent:
+        border:          'base02'
+        background:      'base08'
+        text:            'base07'
+        indicator:       'base08'
+bar_colors:
+    separator:           'base03'
+    background:          'base00'
+    statusline:          'base05'
+    focused_workspace:
+        border:          'base0D'
+        background:      'base0D'
+        text:            'base00'
+    active_workspace:
+        border:          'base02'
+        background:      'base02'
+        text:            'base07'
+    inactive_workspace:
+        border:          'base01'
+        background:      'base01'
+        text:            'base03'
+    urgent_workspace:
+        border:          'base08'
+        background:      'base08'
+        text:            'base07'

--- a/templates/i3/i3.erb
+++ b/templates/i3/i3.erb
@@ -1,0 +1,45 @@
+# ~/.i3/config
+# i3 config template
+# Base16 <%= @scheme %> by <%= @author %>
+# template by Matt Parnell, @parnmatt
+
+set $base00 #<%= @base["00"]["hex"] %>
+set $base01 #<%= @base["01"]["hex"] %>
+set $base02 #<%= @base["02"]["hex"] %>
+set $base03 #<%= @base["03"]["hex"] %>
+set $base04 #<%= @base["04"]["hex"] %>
+set $base05 #<%= @base["05"]["hex"] %>
+set $base06 #<%= @base["06"]["hex"] %>
+set $base07 #<%= @base["07"]["hex"] %>
+set $base08 #<%= @base["08"]["hex"] %>
+set $base09 #<%= @base["09"]["hex"] %>
+set $base0A #<%= @base["0A"]["hex"] %>
+set $base0B #<%= @base["0B"]["hex"] %>
+set $base0C #<%= @base["0C"]["hex"] %>
+set $base0D #<%= @base["0D"]["hex"] %>
+set $base0E #<%= @base["0E"]["hex"] %>
+set $base0F #<%= @base["0F"]["hex"] %>
+
+client.focused $base0D $base0D $base00 $base01
+client.focused_inactive $base02 $base02 $base03 $base01
+client.unfocused $base01 $base01 $base03 $base01
+client.urgent $base02 $base08 $base07 $base08
+
+## remember to add the rest of your configuration
+
+bar {
+    ## remember to add your favourite status bar, i.e.,
+    # status_command i3status
+    
+        colors {
+        separator $base03
+        background $base01
+        statusline $base05
+        focused_workspace $base0C $base0D $base00
+        active_workspace $base02 $base02 $base07
+        inactive_workspace $base01 $base01 $base03
+        urgent_workspace $base08 $base08 $base07
+    }
+}
+
+

--- a/templates/i3status/i3status.erb
+++ b/templates/i3status/i3status.erb
@@ -1,0 +1,13 @@
+# ~/.i3status.conf
+# Base16 <%= @scheme %>, by <%= @author %>
+# template by Matt Parnell, @parnmatt
+
+general {
+    colors = true
+    color_good = "#<%= @base["0B"]["hex"] %>"
+    color_bad = "<%= @base["08"]["hex"] %>"
+    ## remember to add your prefered interval
+    # interval = 5
+}
+
+## remember to add the rest of your configure


### PR DESCRIPTION
The following templates are for consistency with common programs for
i3 window manager.

Direct colours with i3, or via i3-style (GitHub: acrisci/i3-style).
i3status bar colours to match (only good and bad, i.e., green and red).
dmenu, both light and dark theme.