### PR TITLE
add cscope definitions to emacs dark theme template

### DIFF
--- a/templates/emacs/-dark-theme.el.erb
+++ b/templates/emacs/-dark-theme.el.erb
@@ -260,6 +260,13 @@
 
    `(regex-tool-matched-face ((t (:foreground nil :background nil :inherit match))))
 
+   ;; Cscope
+   `(cscope-file-face ((t (:foreground ,base0B))))
+   `(cscope-function-face ((t (:foreground ,base0D))))
+   `(cscope-line-number-face ((t (:foreground ,base0A))))
+   `(cscope-mouse-face ((t (:background ,base01 :foreground ,base04))))
+   `(cscope-separator-face ((t (:foreground ,base08 :overline t :underline t :weight bold))))
+
    ;; mark-multiple
    `(mm/master-face ((t (:inherit region :foreground nil :background nil))))
    `(mm/mirror-face ((t (:inherit region :foreground nil :background nil))))

--- a/templates/emacs/-dark-theme.el.erb
+++ b/templates/emacs/-dark-theme.el.erb
@@ -278,7 +278,7 @@
    `(org-agenda-dimmed-todo-face ((t (:foreground ,base04))))
    `(org-block ((t (:foreground ,base09))))
    `(org-code ((t (:foreground ,base0A))))
-   `(org-column ((t (:background ,base03))))
+   `(org-column ((t (:background ,base01))))
    `(org-column-title ((t (:inherit org-column :weight bold :underline t))))
    `(org-date ((t (:foreground ,base0E :underline t))))
    `(org-document-info ((t (:foreground ,base0C))))


### PR DESCRIPTION
These definitions are similar in style to the existing grep colors.