### PR TITLE
Add Sequel Pro template

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Build a scheme stored on some webspace.
 * Qt Creator
 * Rainbow
 * Rouge
+* Sequel Pro
 * Terminator
 * Termite
 * Textadept
@@ -78,6 +79,7 @@ Build a scheme stored on some webspace.
 * [moonpyk](https://github.com/moonpyk) - ConEmu
 * [jprjr](https://github.com/jprjr) - ConnectBot, vx-connectbot
 * [atelierbram](https://github.com/atelierbram) - Prism
+* [bbrks](https://github.com/bbrks) - Sequel Pro
 
 ## License
 Base16 Builder is released under the [MIT License](https://github.com/chriskempson/base16-builder/blob/master/LICENSE.md)

--- a/templates/sequel-pro/dark.spTheme.erb
+++ b/templates/sequel-pro/dark.spTheme.erb
@@ -1,0 +1,82 @@
+<%
+# Sequel Pro Template
+# Ben Brooks (http://bbrks.me)
+
+%><?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#<%= @base["00"]["hex"] %></string>
+				<key>caret</key>
+				<string>#<%= @base["05"]["hex"] %></string>
+				<key>foreground</key>
+				<string>#<%= @base["05"]["hex"] %></string>
+				<key>lineHighlight</key>
+				<string>#<%= @base["02"]["hex"] %>7F</string>
+				<key>selection</key>
+				<string>#<%= @base["02"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["03"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>String</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["0B"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["0E"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>User-defined constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["0D"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["09"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["08"]["hex"] %></string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/templates/sequel-pro/light.spTheme.erb
+++ b/templates/sequel-pro/light.spTheme.erb
@@ -1,0 +1,82 @@
+<%
+# Sequel Pro Template
+# Ben Brooks (http://bbrks.me)
+
+%><?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#<%= @base["07"]["hex"] %></string>
+				<key>caret</key>
+				<string>#<%= @base["02"]["hex"] %></string>
+				<key>foreground</key>
+				<string>#<%= @base["02"]["hex"] %></string>
+				<key>lineHighlight</key>
+				<string>#<%= @base["06"]["hex"] %>7F</string>
+				<key>selection</key>
+				<string>#<%= @base["06"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Comment</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["03"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>String</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["0B"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keyword</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["0E"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>User-defined constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["0D"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Number</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["09"]["hex"] %></string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#<%= @base["08"]["hex"] %></string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This pull request will add template files to generate [Sequel Pro](http://www.sequelpro.com/) colour schemes.

Examples with Base16 default:

<img width="599" alt="screen shot 2015-10-03 at 01 10 12" src="https://cloud.githubusercontent.com/assets/1525809/10260389/d63809da-696c-11e5-8d43-4dabb2161d4e.png">
<img width="599" alt="screen shot 2015-10-03 at 01 11 01" src="https://cloud.githubusercontent.com/assets/1525809/10260390/d6382000-696c-11e5-93c9-c5f974152766.png">
