### PR TITLE
Emacs: Add face for evil persistent search highlight

### DIFF
--- a/templates/emacs/-dark-theme.el.erb
+++ b/templates/emacs/-dark-theme.el.erb
@@ -80,6 +80,8 @@
    `(isearch ((t (:foreground ,base0A :background ,base01 :inverse-video t))))
    `(isearch-lazy-highlight-face ((t (:foreground ,base0C :background ,base01 :inverse-video t))))
    `(isearch-fail ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
+   `(evil-search-highlight-persist-highlight-face ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
+
 
    ;; Popups
    `(popup-face ((t (:foreground ,base05 :background ,base02))))

--- a/templates/emacs/-light-theme.el.erb
+++ b/templates/emacs/-light-theme.el.erb
@@ -80,6 +80,7 @@
    `(isearch ((t (:foreground ,base0A :background ,base01 :inverse-video t))))
    `(isearch-lazy-highlight-face ((t (:foreground ,base0C :background ,base01 :inverse-video t))))
    `(isearch-fail ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
+   `(evil-search-highlight-persist-highlight-face ((t (:background ,base01 :inherit font-lock-warning-face :inverse-video t))))
 
    ;; Popups
    `(popup-face ((t (:foreground ,base02 :background ,base05))))	


### PR DESCRIPTION
The default bright yellow is somewhat jarring.
