### PR TITLE
shell: Don't use [[ to detect interactive shells

### DIFF
--- a/templates/shell/dark.sh.erb
+++ b/templates/shell/dark.sh.erb
@@ -47,7 +47,7 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [[ $- != *i* ]]; then
+elif ! echo $- | grep -q "i"; then
   # non-interactive
   alias printf=/bin/false
 else

--- a/templates/shell/light.sh.erb
+++ b/templates/shell/light.sh.erb
@@ -47,7 +47,7 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [[ $- != *i* ]]; then
+elif ! echo $- | grep -q "i"; then
   # non-interactive
   alias printf=/bin/false
 else


### PR DESCRIPTION
These scripts claim to be POSIX-compliant with their sh shebangs, but [[
is a feature of bourne shells. The vim colorsheme will try to run the
script with sh as well, which will fail on Ubuntu where sh is dash, not
bash.
