### PR TITLE
Fixes #332 by adding a @base accessor

### DIFF
--- a/base16
+++ b/base16
@@ -10,7 +10,7 @@ require "base64"
 class Theme
   BASE_PATH = File.dirname(__FILE__)
 
-  attr_accessor :template
+  attr_accessor :template, :base
 
   def initialize
     @scheme_dir = File.join(BASE_PATH, "schemes")


### PR DESCRIPTION
This allow to use base as well as @base in the erb templates, allowing all template and schemes to build.