### PR TITLE
Vim: Fix for Neovim terminal mode

### DIFF
--- a/templates/vim/vim.erb
+++ b/templates/vim/vim.erb
@@ -33,6 +33,32 @@ let s:gui0D = "<%= @base["0D"]["hex"] %>"
 let s:gui0E = "<%= @base["0E"]["hex"] %>"
 let s:gui0F = "<%= @base["0F"]["hex"] %>"
 
+" Neovim color definitions for terminal mode
+if has("nvim")
+  let g:terminal_color_0 =  "#" . s:gui00
+  let g:terminal_color_1 =  "#" . s:gui08
+  let g:terminal_color_2 =  "#" . s:gui0B
+  let g:terminal_color_3 =  "#" . s:gui0A
+  let g:terminal_color_4 =  "#" . s:gui0D
+  let g:terminal_color_5 =  "#" . s:gui0E
+  let g:terminal_color_6 =  "#" . s:gui0C
+  let g:terminal_color_7 =  "#" . s:gui05
+  let g:terminal_color_8 =  "#" . s:gui03
+  let g:terminal_color_9 =  "#" . s:gui09
+  let g:terminal_color_10 = "#" . s:gui01
+  let g:terminal_color_11 = "#" . s:gui02
+  let g:terminal_color_12 = "#" . s:gui04
+  let g:terminal_color_13 = "#" . s:gui06
+  let g:terminal_color_14 = "#" . s:gui0F
+  let g:terminal_color_15 = "#" . s:gui07
+  let g:terminal_color_background = g:terminal_color_0
+  let g:terminal_color_foreground = g:terminal_color_7
+  if &background == "light"
+    let g:terminal_color_background = g:terminal_color_7
+    let g:terminal_color_foreground = g:terminal_color_2
+  endif
+endif
+
 " Terminal color definitions
 let s:cterm00 = "00"
 let s:cterm03 = "08"


### PR DESCRIPTION
Fix for https://github.com/chriskempson/base16-vim/issues/69
This work for both light and dark versions of themes.
