### PR TITLE
Fix specifying a template with `-t` that includes the `templates` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Build only the "default" theme
     > ./base16 https://awesome-schemes.com/my-scheme.yml
 Build a scheme stored on some webspace.
 
+    > ./base16 -t templates/terminal-app
+Build only the terminal-app termplate
+
 ## Templates
 * Atom
 * BBEdit (TextWrangler)

--- a/base16
+++ b/base16
@@ -58,7 +58,7 @@ class Theme
   end
 
   def build_single_template(template_dir)
-    @template_dir = File.join(BASE_PATH, "templates", template_dir)
+    @template_dir = File.join(BASE_PATH, "**", template_dir)
   rescue StandardError
     abort(read_error_message(@template_dir))
   end


### PR DESCRIPTION
When building specific schemes, the path is explicitly written (e.g. `./base16 -s schemes/tomorrow.yml`), however the current behavior of the `-t` switch (for building a specific template) requires passing just the name of the directory _under_ the templates dir (e.g. `./base16 -t shell`).

This is inconsistent behaviour. With this pull request, the user can include the template directory in the switch (without effecting current behaviour):

```
$ ./base16 -t templates/terminal-app
./schemes/3024.yml
  - ./templates/terminal-app/dark.256.terminal.erb
  - ./templates/terminal-app/dark.terminal.erb
  - ./templates/terminal-app/light.terminal.erb
./schemes/apathy.yml
  - ./templates/terminal-app/dark.256.terminal.erb
  - ./templates/terminal-app/dark.terminal.erb
  - ./templates/terminal-app/light.terminal.erb
...
$ ./base16 -t shell
./schemes/3024.yml
  - ./templates/shell/dark.sh.erb
  - ./templates/shell/light.sh.erb
./schemes/apathy.yml
  - ./templates/shell/dark.sh.erb
  - ./templates/shell/light.sh.erb
...
```

Lastly, this PR adds documentation about the `-t` flag to the README.
