### PR TITLE
Fix syntax error in `@base` call in dmenu template

### DIFF
--- a/templates/dmenu/dark.erb
+++ b/templates/dmenu/dark.erb
@@ -3,4 +3,4 @@
 # template by Matt Parnell, @parnmatt
 
 # add this as an alias, or however you wish to run dmenu
-dmenu -nb '<%= base["00"]["hex"] %>' -nf '<%= base["03"]["hex"] %>' -sb '<%= base["0D"]["hex"] %>' -sf '<%= base["00"]["hex"] %>'
+dmenu -nb '<%= @base["00"]["hex"] %>' -nf '<%= @base["03"]["hex"] %>' -sb '<%= @base["0D"]["hex"] %>' -sf '<%= @base["00"]["hex"] %>'

--- a/templates/dmenu/light.erb
+++ b/templates/dmenu/light.erb
@@ -3,4 +3,4 @@
 # template by Matt Parnell, @parnmatt
 
 # add this as an alias, or however you wish to run dmenu
-dmenu -nb '<%= base["05"]["hex"] %>' -nf '<%= base["02"]["hex"] %>' -sb '<%= base["0D"]["hex"] %>' -sf '<%= base["01"]["hex"] %>'
+dmenu -nb '<%= @base["05"]["hex"] %>' -nf '<%= @base["02"]["hex"] %>' -sb '<%= @base["0D"]["hex"] %>' -sf '<%= @base["01"]["hex"] %>'


### PR DESCRIPTION
This PR fixes a bug in the dmenu template, which cause the `base16` script to fail. The template was calling `base` instead of `@base` to obtain the base16 hex values.