### PR TITLE
Never print escapes for interactive sessions

### DIFF
--- a/templates/shell/dark.sh.erb
+++ b/templates/shell/dark.sh.erb
@@ -47,13 +47,15 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [[ $- != *i* ]]; then
-  # non-interactive
-  alias printf=/bin/false
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"
   printf_template_custom="\033]%s%s\033\\"
+fi
+
+if [ $- != *i* ]; then
+  # non-interactive
+  alias printf=/bin/false
 fi
 
 # 16 color space

--- a/templates/shell/light.sh.erb
+++ b/templates/shell/light.sh.erb
@@ -47,13 +47,15 @@ elif [ "${TERM%%-*}" = "screen" ]; then
   printf_template="\033P\033]4;%d;rgb:%s\007\033\\"
   printf_template_var="\033P\033]%d;rgb:%s\007\033\\"
   printf_template_custom="\033P\033]%s%s\007\033\\"
-elif [[ $- != *i* ]]; then
-  # non-interactive
-  alias printf=/bin/false
 else
   printf_template="\033]4;%d;rgb:%s\033\\"
   printf_template_var="\033]%d;rgb:%s\033\\"
   printf_template_custom="\033]%s%s\033\\"
+fi
+
+if [ $- != *i* ]; then
+  # non-interactive
+  alias printf=/bin/false
 fi
 
 # 16 color space


### PR DESCRIPTION
#214 turns out not to be completely solved by #215. In particular, when screen or tmux is in use, escapes are still printed, even for non-interactive sessions. This PR fixes that problem. Should also be used to rebuild base16-shell to fix chriskempson/base16-shell#42.
