### PR TITLE
Fix scripts for gnome-terminal

### DIFF
--- a/templates/gnome-terminal/dark.sh.erb
+++ b/templates/gnome-terminal/dark.sh.erb
@@ -40,7 +40,7 @@ dlist_append() {
 # Newest versions of gnome-terminal use dconf
 if which "$DCONF" > /dev/null 2>&1; then
     #check that uuidgen is available
-    type $UUIDGEN >/dev/null 2>&1 || { echo >&2 "Requires uuidgen but it's not installed.  Aborting!"; return 1; }
+    type $UUIDGEN >/dev/null 2>&1 || { echo >&2 "Requires uuidgen but it's not installed.  Aborting!"; exit 1; }
 
     [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
 
@@ -78,7 +78,7 @@ if which "$DCONF" > /dev/null 2>&1; then
         unset PROFILE_SLUG
         unset DCONF
         unset UUIDGEN
-        return 0
+        exit 0
     fi
 fi
 

--- a/templates/gnome-terminal/light.sh.erb
+++ b/templates/gnome-terminal/light.sh.erb
@@ -40,7 +40,7 @@ dlist_append() {
 # Newest versions of gnome-terminal use dconf
 if which "$DCONF" > /dev/null 2>&1; then
     #check that uuidgen is available
-    type $UUIDGEN >/dev/null 2>&1 || { echo >&2 "Requires uuidgen but it's not installed.  Aborting!"; return 1; }
+    type $UUIDGEN >/dev/null 2>&1 || { echo >&2 "Requires uuidgen but it's not installed.  Aborting!"; exit 1; }
 
     [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
 
@@ -79,7 +79,7 @@ if which "$DCONF" > /dev/null 2>&1; then
         unset PROFILE_SLUG
         unset DCONF
         unset UUIDGEN
-        return 0
+        exit 0
     fi
 fi
 


### PR DESCRIPTION
return can only be used inside functions, use exit instead.