### PR TITLE
readme: updated to show -t usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Build only the "default" theme
     > ./base16 https://awesome-schemes.com/my-scheme.yml
 Build a scheme stored on some webspace.
 
+    > ./base16 -t textadept
+Build schemes only for the Textadept texteditor
+
+    > ./base16 -t textadept -s default.yml
+Build only the "default" theme for the Textadept texteditor
+
 ## Templates
 * Atom
 * BBEdit (TextWrangler)


### PR DESCRIPTION
I noticed that for whatever reason, when I originally wrote the
[build_single_template](https://github.com/chriskempson/base16-builder/pull/210) feature, I never updated the `README.md` to give a
simple usage scenario. Anyway, this PR is to rectify that wrong and help
out a few people whom haven't notice the extra CLI ability of your excellent
theme builder. :)
