### PR TITLE
tmux: compare `tty` with `pane_tty`

### DIFF
--- a/templates/shell/dark.sh.erb
+++ b/templates/shell/dark.sh.erb
@@ -36,7 +36,8 @@ color_foreground="<%= split_by_slash(@base["05"]["hex"]) %>" # Base 05
 color_background="<%= split_by_slash(@base["00"]["hex"]) %>" # Base 00
 color_cursor="<%= split_by_slash(@base["05"]["hex"]) %>" # Base 05
 
-if [ -n "$TMUX" ]; then
+if [ -n "$TMUX" ] && ([ -n "$TTY" ] && tty="$TTY" || tty="$(tty)") \
+    && [ "$tty" = "$(tmux display -p '#{pane_tty}')" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
   printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"

--- a/templates/shell/light.sh.erb
+++ b/templates/shell/light.sh.erb
@@ -36,7 +36,8 @@ color_foreground="<%= split_by_slash(@base["02"]["hex"]) %>" # Base 02
 color_background="<%= split_by_slash(@base["07"]["hex"]) %>" # Base 07
 color_cursor="<%= split_by_slash(@base["02"]["hex"]) %>" # Base 02
 
-if [ -n "$TMUX" ]; then
+if [ -n "$TMUX" ] && ([ -n "$TTY" ] && tty="$TTY" || tty="$(tty)") \
+    && [ "$tty" = "$(tmux display -p '#{pane_tty}')" ]; then
   # tell tmux to pass the escape sequences through
   # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
   printf_template="\033Ptmux;\033\033]4;%d;rgb:%s\007\033\\"


### PR DESCRIPTION
`$TMUX` would be set when starting a new terminal emulator from inside
of a pane (e.g. urxvt), but then the escape codes should not be wrapped
for tmux.

`pane_tty` exists since tmux 1.6 (released in 2012),
`tmux display -p` since 1.2.
